### PR TITLE
SAP: draft intercurrent events section (#23)

### DIFF
--- a/statistical-analysis-plan/statistical-analysis-plan.qmd
+++ b/statistical-analysis-plan/statistical-analysis-plan.qmd
@@ -377,11 +377,20 @@ cat("\\restoregeometry\n")
 
 ## Intercurrent events
 
-<!-- Should include:
-- Anticipated cluster-level and individual-level intercurrent events (e.g., death, non-adherence) and details of how these data will be presented (including timing)
-- Strategies to handle cluster-level and individual-level intercurrent events (e.g., treatment policy strategy, principal stratum strategy)
-- Assumptions made under each intercurrent event strategy (e.g., under while alive strategy that the death is independent of treatment) 
--->
+<!-- github-issue-23: draft ICE strategies from outcomes-summary table and existing outcome analysis text. -->
+Intercurrent events are events occurring after intervention exposure that affect interpretation or occurrence of an outcome. Anticipated events and the strategy used for each outcome are summarised in @tbl-outcomes-summary. Frequencies of these events (including timing where informative) will be presented overall and by intervention condition.
+
+At the cluster level, late or early transition relative to the scheduled date, incomplete delivery of ATLS® training, and cluster dropout are treated as protocol or adherence issues (see Adherence and Protocol deviations) rather than as outcome-specific intercurrent events; exposure for analysis remains as defined under Analysis sets, with a sensitivity analysis using the actual transition date when the deviation exceeds four weeks.
+
+At the individual level, the main intercurrent events and strategies are as follows.
+
+- **Loss to follow-up and withdrawal of consent.** For mortality outcomes, these events primarily create missingness and are handled under the missing-data plan (@sec-treatment-of-missing-data). Participants who withdraw from further non-routine data collection contribute observed outcomes up to withdrawal unless they also request removal of already collected data.
+- **Transfer to another hospital.** For the primary outcome (in-hospital mortality within 30 days), deaths after transfer are included in the outcome definition (treatment-policy handling of transfer with respect to the mortality endpoint). For all-cause mortality secondary outcomes, deaths are counted regardless of care setting.
+- **Death and transfer for length-of-stay and ICU outcomes.** Observed length of emergency department, hospital, and ICU stay is the completed duration to exit; death or transfer truncates the observed stay and is not treated as censoring. ICU admission is classified according to whether admission occurred before death or transfer.
+- **Death before a survivor-only outcome.** Quality of life, disability, and return to work are defined only among patients alive at the relevant follow-up (a principal-stratum / while-alive restriction). The analyses therefore target effects in survivors at that time point; mortality is analysed separately. Return to work is further restricted to patients for whom the outcome is relevant.
+- **Non-observation of nested adherence.** Adherence to ATLS® principles is analysed in the observed nested-staircase sample; patients not selected for observation or with an incomplete observation window do not contribute to that analysis.
+
+Where a while-alive or survivors-only strategy is used, we assume that, conditional on the analysis model and design factors, the occurrence of death before the outcome assessment does not induce selection bias beyond what is addressed by analysing mortality separately; sensitivity of conclusions will rely on joint interpretation of mortality and survivor outcomes. Assumptions underlying each strategy will be considered when interpreting results and when checking model assumptions (see Analysis methods).
 
 ## Population
 


### PR DESCRIPTION
## Summary
- Draft the Intercurrent events section using `@tbl-outcomes-summary` and existing outcome-analysis wording (#23).
- Cover loss to follow-up/withdrawal, transfer, death for length-of-stay and ICU outcomes, survivors-only outcomes, and nested adherence non-observation, with brief strategy assumptions.

## Test plan
- [ ] Cross-check each bullet against `tables/outcomes-summary.json`
- [ ] Confirm no contradiction with Analysis sets or secondary-outcome death/transfer text
- [ ] Render PDF and check section placement under Intercurrent events, populations and summary measures

Depends on #27 (base branch).


Made with [Cursor](https://cursor.com)