### PR TITLE
SAP: tidy method-text and shell-table repetition (#15, #34)

### DIFF
--- a/functions/create_additional_analyses_results_table.R
+++ b/functions/create_additional_analyses_results_table.R
@@ -2,8 +2,9 @@
 #'
 #' Blank `gtsummary::tbl_regression`-style shell for primary-outcome sensitivity
 #' analyses, the fully adjusted analysis, and subgroup analyses. Layout matches
-#' the main analysis-results shells: section headers, effect measure folded into
-#' the outcome label, and blank Estimate / 95% CI / p-value columns.
+#' the main analysis-results shells: top-level section headers, nested analysis
+#' names, effect-measure labels indented with [gtsummary::modify_indent()], and
+#' blank Estimate / 95% CI / p-value columns.
 #'
 #' @param label.width Numeric. Fraction of linewidth for the label column in
 #'     LaTeX output. Defaults to `0.50`.
@@ -44,7 +45,15 @@ create_additional_analyses_results_table <- function(label.width = 0.50) {
         list(field = spec$field, section = spec$section)
     })
     results.table <- insert_table_section_headers(results.table, section.requests)
-    section.labels <- get_table_section_labels(section.requests)
+    ## Bold only top-level headers; nested analysis names stay regular weight
+    section.labels <- get_table_section_labels(section.requests, depth = 1L)
+
+    results.table <- gtsummary::modify_indent(
+        results.table,
+        columns = label,
+        rows = row_type == "label",
+        indent = 4L
+    )
 
     results.table <- gtsummary::modify_table_body(
         results.table,
@@ -81,7 +90,7 @@ create_additional_analyses_results_table <- function(label.width = 0.50) {
         results.table <- gtsummary::modify_table_styling(
             results.table,
             columns = label,
-            rows = row_type == "section",
+            rows = row_type == "section" & section_depth == 1L,
             text_format = "bold"
         )
     }
@@ -224,7 +233,9 @@ build_subgroup_forest_plot_rows <- function() {
 
 #' Build row specifications for the additional-analyses results shell
 #'
-#' @return A list of specs with `field`, `label`, `measure`, and `section`.
+#' @return A list of specs with `field`, `label`, `measure`, and `section`
+#'     (`section` is a character vector: top-level header, then analysis name
+#'     when the analysis name is not identical to the top-level header).
 build_additional_analyses_results_specs <- function() {
     measure.labels <- c(
         "OR" = "Odds ratio",
@@ -234,20 +245,26 @@ build_additional_analyses_results_specs <- function() {
     specs <- list()
     counter <- 0L
 
-    add.spec <- function(section, label, measure) {
+    add.spec <- function(section, analysis.label = NULL, measure) {
         counter <<- counter + 1L
         measure.label <- unname(measure.labels[[measure]])
+        section.path <- if (is.null(analysis.label) ||
+            identical(analysis.label, section)) {
+            section
+        } else {
+            c(section, analysis.label)
+        }
         specs[[length(specs) + 1L]] <<- list(
             field = paste0("additional_analysis_", counter),
-            label = paste0(label, ", ", measure.label),
+            label = measure.label,
             measure = measure,
-            section = section
+            section = section.path
         )
     }
 
-    add.pair <- function(section, label) {
-        add.spec(section, label, "OR")
-        add.spec(section, label, "ARD")
+    add.pair <- function(section, analysis.label = NULL) {
+        add.spec(section, analysis.label, "OR")
+        add.spec(section, analysis.label, "ARD")
     }
 
     sensitivity <- "Sensitivity analyses"
@@ -258,8 +275,7 @@ build_additional_analyses_results_specs <- function() {
     add.pair(sensitivity, "Lag and weaning effects (periods since first exposure)")
     add.pair(sensitivity, "Actual date of transition for intervention exposure")
 
-    adjusted <- "Fully adjusted analysis"
-    add.pair(adjusted, "Fully adjusted analysis")
+    add.pair("Fully adjusted analysis")
 
     subgroup <- "Subgroup analyses"
     for (label in subgroup_analysis_row_labels()) {

--- a/functions/create_outcomes_analysis_results_table.R
+++ b/functions/create_outcomes_analysis_results_table.R
@@ -3,9 +3,9 @@
 #' Builds a blank `gtsummary` results shell in the style of
 #' `gtsummary::tbl_regression`. One stacked regression row is created for each
 #' outcome–effect-measure combination. Estimate, confidence-interval, and
-#' p-value cells are blanked for the analysis plan. Section headers and label
-#' style match the descriptive outcomes shells (effect measure folded into the
-#' outcome label, as with `, n (%)` in descriptive tables).
+#' p-value cells are blanked for the analysis plan. Design sections nest
+#' outcome names as headers, with effect-measure labels indented underneath
+#' via [gtsummary::modify_indent()] (avoiding repeated outcome names).
 #'
 #' @param data A data frame or NULL. Outcomes summary with columns
 #'     `outcome`, `design_component`, and `effect_measure`. If NULL, reads
@@ -77,7 +77,15 @@ create_outcomes_analysis_results_table <- function(
         )
     })
     results.table <- insert_table_section_headers(results.table, section.requests)
-    section.labels <- get_table_section_labels(section.requests)
+    ## Bold only top-level design headers; nested outcome names stay regular
+    section.labels <- get_table_section_labels(section.requests, depth = 1L)
+
+    results.table <- gtsummary::modify_indent(
+        results.table,
+        columns = label,
+        rows = row_type == "label",
+        indent = 4L
+    )
 
     results.table <- gtsummary::modify_table_body(
         results.table,
@@ -117,7 +125,7 @@ create_outcomes_analysis_results_table <- function(
         results.table <- gtsummary::modify_table_styling(
             results.table,
             columns = label,
-            rows = row_type == "section",
+            rows = row_type == "section" & section_depth == 1L,
             text_format = "bold"
         )
     }
@@ -176,7 +184,8 @@ create_outcomes_analysis_results_table <- function(
 #' @param data Data frame of outcomes summary rows.
 #' @param all Logical. Expand nested QoL/disability to domain-level rows.
 #' @return A list of specs with `field`, `label`, `measure`, `effect_measure`,
-#'     `outcome_type`, `design`, `timing`, and `section`.
+#'     `outcome_type`, `design`, `timing`, and `section` (`section` is a
+#'     character vector: design header then outcome name).
 build_outcomes_analysis_results_specs <- function(data, all = FALSE) {
     measure.labels <- c(
         "OR" = "Odds ratio",
@@ -213,19 +222,20 @@ build_outcomes_analysis_results_specs <- function(data, all = FALSE) {
         } else {
             measure
         }
+        top.section <- outcomes_shell_section_for(
+            outcome_type = outcome_type,
+            design = design,
+            timing = timing
+        )
         specs[[length(specs) + 1L]] <<- list(
             field = paste0("analysis_result_", counter),
-            label = paste0(label, ", ", measure.label),
+            label = measure.label,
             measure = measure,
             effect_measure = measure.label,
             outcome_type = outcome_type,
             design = design,
             timing = timing,
-            section = outcomes_shell_section_for(
-                outcome_type = outcome_type,
-                design = design,
-                timing = timing
-            )
+            section = c(top.section, label)
         )
     }
 
@@ -301,7 +311,7 @@ build_outcomes_analysis_results_specs <- function(data, all = FALSE) {
     }
 
     section.ranks <- match(
-        vapply(specs, function(spec) spec$section, character(1)),
+        vapply(specs, function(spec) spec$section[[1]], character(1)),
         section.order
     )
     section.ranks[is.na(section.ranks)] <- length(section.order) + 1L

--- a/statistical-analysis-plan/statistical-analysis-plan.qmd
+++ b/statistical-analysis-plan/statistical-analysis-plan.qmd
@@ -591,22 +591,22 @@ $$
 \end{aligned}
 $$ {#eq-distributional-assumptions}
 
-To correct potential inflation of the type I error rate due to the small number of clusters, a small-sample correction will be applied. Our primary method will be the Kenward–Roger correction [@grantham_evaluating_2022], but this choice may be updated based on methodological developments available closer to the end of patient inclusion. The correction applied may also differ for outcomes collected via the complete stepped-wedge design and the incomplete nested staircase designs.
-
+<!-- github-issue-15: deduplicate B3/A1/B2 with overview and software sections. -->
 <!-- sap-revision-todo B3 (comments id=21, id=22 AO; Round Two 27c/27d): model-based SEs, small-sample adjustments, Wald-type CIs. -->
-Standard errors will be model-based. Small-sample adjustments, including degrees-of-freedom corrections such as Kenward–Roger, will be applied where relevant. Confidence intervals will be Wald-type.
+Standard errors will be model-based. Confidence intervals will be Wald-type. To correct potential inflation of the type I error rate due to the small number of clusters, a small-sample correction will be applied. Our primary method will be the Kenward–Roger correction [@grantham_evaluating_2022], but this choice may be updated based on methodological developments available closer to the end of patient inclusion. The correction applied may also differ for outcomes collected via the complete stepped-wedge design and the incomplete nested staircase designs.
 
 <!-- sap-revision-todo A1 (comments id=199 KH, id=200 AO); B4 (comment id=23 AO; Round Two 27b): general estimation framework is ML with Laplace; package/implementation not prespecified. -->
-The general estimation framework for the mixed-effects models is maximum likelihood, with a Laplace approximation used to integrate out the random effects. The specific R package and numerical implementation will be chosen based on convergence behaviour and the availability of appropriate small-sample corrections closer to the time of analysis. 
+The general estimation framework for the mixed-effects models is maximum likelihood, with a Laplace approximation used to integrate out the random effects. The specific R package and numerical implementation are not prespecified (see Statistical software).
 
 <!-- sap-revision-todo B2 (comments id=24 MGW, id=25 AO; Round Two): state that diagnostics will check distributional assumptions and convergence. -->
 Model diagnostics will be used to assess distributional assumptions and model convergence.
 
 ### Analysis of secondary outcomes
 
+<!-- github-issue-15: keep only ordinal-specific diagnostics here; general diagnostics under primary. -->
 <!-- sap-revision-todo B2 (comments id=24 MGW, id=25 AO; Round Two): diagnostics for secondary models, including proportional odds for ordinal outcomes. -->
 <!-- sap-revision-todo H1 (comments id=14, id=15, id=17 MGW/AO; Round Two): effect measures by outcome type; no HR after A2; cluster-specific estimates. -->
-Unless otherwise stated, secondary outcomes will be analysed using the same mixed-effects modelling framework as specified for the primary outcome, including fixed effects for time and intervention exposure and random effects for cluster and cluster-by-period, with the link function and outcome distribution adapted to the scale of the outcome. Effect measures are odds ratios and absolute risk differences for binary outcomes, rate ratios for count (length-of-stay) outcomes, cumulative odds ratios for ordinal outcomes, mean differences for continuous outcomes, and a logit-scale difference for the adherence proportion. These models provide cluster-specific estimates of the intervention effect for patient-level outcomes. Model diagnostics will be used to assess distributional assumptions, the proportional-odds assumption for cumulative logit models, and model convergence.
+Unless otherwise stated, secondary outcomes will be analysed using the same mixed-effects modelling framework as specified for the primary outcome, including fixed effects for time and intervention exposure and random effects for cluster and cluster-by-period, with the link function and outcome distribution adapted to the scale of the outcome. Effect measures are odds ratios and absolute risk differences for binary outcomes, rate ratios for count (length-of-stay) outcomes, cumulative odds ratios for ordinal outcomes, mean differences for continuous outcomes, and a logit-scale difference for the adherence proportion. These models provide cluster-specific estimates of the intervention effect for patient-level outcomes. For cumulative logit models, diagnostics will also assess the proportional-odds assumption.
 
 #### All cause mortality within 24 hours, 30 days and three months of arrival at the emergency department
 
@@ -890,6 +890,7 @@ We will use the R Statistical Software for all analyses [@R]. Specific packages 
 ## Presentation of analysis results
 
 <!-- sap-revision-todo J2: gtsummary tbl_regression-style key/all shells; shared descriptive section headers and label style. -->
+<!-- github-issue-34: outcome names as nested headers; effect measures indented with modify_indent. -->
 Intervention-effect estimates for the primary and secondary outcomes will be reported with 95% CIs and p-values, using the effect measures specified for each outcome. We will present key outcome analyses in the results section, and present all outcome analyses as supplementary tables. See @tbl-outcomes-analysis-results for key analyses and @tbl-outcomes-analysis-results-all for all analyses.
 
 ```{r}
@@ -903,6 +904,7 @@ create_outcomes_analysis_results_table()
 ```
 
 <!-- sap-revision-todo J3: shell for sensitivity, fully adjusted, and subgroup analyses of the primary outcome. -->
+<!-- github-issue-34: analysis names as nested headers; OR/ARD indented with modify_indent. -->
 Sensitivity, fully adjusted, and subgroup analyses of the primary outcome will be reported in the same style. See @tbl-additional-analyses-results. Subgroup-specific intervention effects will also be presented in a forest plot with 95% CIs for the odds ratio and absolute risk difference. See @fig-subgroup-forest-plot.
 
 ```{r}
@@ -932,8 +934,9 @@ knitr::include_graphics(
 )
 ```
 
+<!-- github-issue-15: avoid repeating B5–B6 detail; cross-ref Correlations. -->
 <!-- sap-revision-todo J6: shell for ICC, variance components, and related correlations (B5-B6); supplementary only. -->
-Time-adjusted within-cluster correlations and variance components will be reported with 95% CIs for all outcomes, as specified above; for binary outcomes, latent-scale correlations will additionally be reported. For models with an AR(1) within-cluster structure, the within-period correlation and correlation decay parameter will also be reported. These parameters will be presented as a supplementary table. See @tbl-correlation-parameters.
+Time-adjusted within-cluster correlations and variance components will be presented as a supplementary table, as specified under Correlations. See @tbl-correlation-parameters.
 
 # Supplementary tables
 


### PR DESCRIPTION
## Summary
- **#15:** Deduplicate B3/A1/B2 wording against the methods overview and software section; keep only ordinal-specific diagnostics under secondary outcomes; shorten the presentation correlations paragraph to a cross-reference to Correlations (B5–B6).
- **#34:** Nest outcome/analysis names as section headers in `@tbl-outcomes-analysis-results` and `@tbl-additional-analyses-results`, with effect-measure rows indented via `gtsummary::modify_indent()` so names are not repeated on every OR/ARD row.

## Test plan
- [ ] Spot-check primary-analysis / secondary / Correlations / Presentation wording in the rendered SAP
- [ ] Confirm analysis-results and additional-analyses shells show nested headers with indented Odds ratio / Absolute risk difference rows
- [ ] Confirm only top-level section headers are bold

Closes #15
Closes #34

Made with [Cursor](https://cursor.com)