### PR TITLE
Interactive forest plot with chronological pooling reveal

### DIFF
--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -63,3 +63,13 @@ Typed accessors are in `src/figure-data.ts`. Regenerate after changing systemati
 ```bash
 Rscript export-figure-data.R
 ```
+
+### Interactive forest plot
+
+On the `#atls-forest` slide you can:
+
+- Click a study row to include or exclude it
+- Use the chips to show all studies or only one study design
+- Watch the pooled diamond, CI, and I² update live
+
+When every study is included, the plot shows the R-exported REML pooled estimate (same as the protocol). Subsets are re-pooled in the browser with inverse-variance DerSimonian–Laird random effects (`src/pool-meta.ts`).

--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -68,8 +68,9 @@ Rscript export-figure-data.R
 
 On the `#atls-forest` slide you can:
 
+- Watch studies appear oldest → newest on enter, with the pooled estimate updating after each
+- Click **Play timeline** to replay that chronological reveal
 - Click a study row to include or exclude it
 - Use the chips to show all studies or only one study design
-- Watch the pooled diamond, CI, and I² update live
 
 When every study is included, the plot shows the R-exported REML pooled estimate (same as the protocol). Subsets are re-pooled in the browser with inverse-variance DerSimonian–Laird random effects (`src/pool-meta.ts`).

--- a/presentations/atls-sweden-30-years/src/forest-plot.ts
+++ b/presentations/atls-sweden-30-years/src/forest-plot.ts
@@ -1,4 +1,5 @@
 import { metaAnalysis, type MetaAnalysisData } from "./figure-data";
+import { poolRandomEffects, sameStudySet, type PooledEstimate } from "./pool-meta";
 
 const ROW_HEIGHT = 18;
 const LABEL_WIDTH = 186;
@@ -8,6 +9,7 @@ const EFFECT_WIDTH = 96;
 const PAD_LEFT = 4;
 const PAD_TOP = 22;
 const AXIS_HEIGHT = 28;
+const DIAMOND_H = 7;
 
 function svgEl(tag: string, attrs: Record<string, string | number> = {}): SVGElement {
   const el = document.createElementNS("http://www.w3.org/2000/svg", tag);
@@ -26,23 +28,115 @@ function formatRr(value: number): string {
   return value.toFixed(2);
 }
 
-export function createForestPlotSvg(data: MetaAnalysisData = metaAnalysis): SVGSVGElement {
-  const totalWidth = PAD_LEFT + LABEL_WIDTH + N_WIDTH + FOREST_WIDTH + EFFECT_WIDTH + 8;
-  const totalHeight = PAD_TOP + (data.studies.length + 1) * ROW_HEIGHT + AXIS_HEIGHT + 8;
+function diamondPoints(
+  logRr: number,
+  ciLower: number,
+  ciUpper: number,
+  y: number,
+  xlim: [number, number],
+  forestX: number
+): string {
+  const px = logToX(logRr, xlim, forestX);
+  const pLo = Math.max(logToX(Math.log(ciLower), xlim, forestX), forestX);
+  const pHi = Math.min(logToX(Math.log(ciUpper), xlim, forestX), forestX + FOREST_WIDTH);
+  return `${pLo},${y} ${px},${y - DIAMOND_H} ${pHi},${y} ${px},${y + DIAMOND_H}`;
+}
+
+function footerText(pooled: PooledEstimate, measure: string): string {
+  return (
+    `Random-effects ${measure} ${pooled.rrFormatted} ` +
+    `(95% CI ${pooled.ciFormatted.replace("; ", "–")}); ` +
+    `I² ${pooled.i2Rounded.toFixed(2)}; ` +
+    `${pooled.numberOfStudies} observational ${pooled.numberOfStudies === 1 ? "study" : "studies"}`
+  );
+}
+
+/** Compact filters for live presentation use. */
+const DESIGN_FILTERS: { label: string; match: (design: string) => boolean }[] = [
+  {
+    label: "Prospective",
+    match: (design) => /prospective/i.test(design) || design === "Cohort study",
+  },
+  {
+    label: "Retrospective",
+    match: (design) => /retrospective/i.test(design),
+  },
+  {
+    label: "Registry",
+    match: (design) => /registry/i.test(design),
+  },
+];
+
+export interface ForestPlotController {
+  element: HTMLElement;
+  setIncluded(keys: Iterable<string>): void;
+  includeAll(): void;
+  getIncluded(): Set<string>;
+}
+
+/**
+ * Interactive forest plot: click a study row to include/exclude it.
+ * The pooled diamond and footer update from an inverse-variance
+ * DerSimonian–Laird random-effects model. When every study is included,
+ * the R-exported REML pooled estimate is shown so the full set matches
+ * the protocol figure.
+ */
+export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestPlotController {
+  const allKeys = data.studies.map((s) => s.citationKey);
+  const included = new Set(allKeys);
+  const maxWeight = Math.max(...data.studies.map((s) => s.weightPercent));
   const forestX = PAD_LEFT + LABEL_WIDTH + N_WIDTH;
   const [xMin, xMax] = data.logScaleXlim;
-  const maxWeight = Math.max(...data.studies.map((s) => s.weightPercent));
+  const totalWidth = PAD_LEFT + LABEL_WIDTH + N_WIDTH + FOREST_WIDTH + EFFECT_WIDTH + 8;
+  const totalHeight = PAD_TOP + (data.studies.length + 1) * ROW_HEIGHT + AXIS_HEIGHT + 8;
+  const pooledY = PAD_TOP + data.studies.length * ROW_HEIGHT + ROW_HEIGHT / 2;
   const nullX = logToX(0, data.logScaleXlim, forestX);
+
+  const panel = document.createElement("div");
+  panel.className = "forest-panel";
+
+  const controls = document.createElement("div");
+  controls.className = "forest-controls";
+  controls.setAttribute("data-animate", "");
+
+  const allBtn = document.createElement("button");
+  allBtn.type = "button";
+  allBtn.className = "forest-chip is-active";
+  allBtn.textContent = "All studies";
+  allBtn.dataset.filter = "all";
+  allBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    includeAll();
+  });
+  controls.appendChild(allBtn);
+
+  for (const filter of DESIGN_FILTERS) {
+    const keys = data.studies.filter((s) => filter.match(s.design)).map((s) => s.citationKey);
+    if (keys.length === 0) continue;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "forest-chip";
+    btn.dataset.filter = filter.label;
+    btn.textContent = filter.label;
+    btn.title = `Include only ${filter.label.toLowerCase()} studies`;
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      setIncluded(keys);
+    });
+    controls.appendChild(btn);
+  }
+
+  const hint = document.createElement("p");
+  hint.className = "forest-hint";
+  hint.textContent = "Click a study to include or exclude it";
+  controls.appendChild(hint);
+  panel.appendChild(controls);
 
   const svg = svgEl("svg", {
     viewBox: `0 0 ${totalWidth} ${totalHeight}`,
     class: "forest-plot-chart",
     role: "img",
   }) as SVGSVGElement;
-  svg.setAttribute(
-    "aria-label",
-    `Forest plot of ATLS effect on mortality. Pooled risk ratio ${data.pooled.rrFormatted}, 95% CI ${data.pooled.ciFormatted}`
-  );
 
   const headerStudy = svgEl("text", { x: PAD_LEFT, y: 14, class: "forest-header" });
   headerStudy.textContent = data.labels.study;
@@ -73,9 +167,26 @@ export function createForestPlotSvg(data: MetaAnalysisData = metaAnalysis): SVGS
     })
   );
 
+  const rowEls = new Map<string, SVGGElement>();
+
   data.studies.forEach((study, i) => {
     const y = PAD_TOP + i * ROW_HEIGHT + ROW_HEIGHT / 2;
-    const row = svgEl("g", { class: "forest-row" });
+    const row = svgEl("g", {
+      class: "forest-row forest-row--interactive",
+      "data-citation-key": study.citationKey,
+      tabindex: 0,
+      role: "button",
+      "aria-pressed": "true",
+    }) as SVGGElement;
+
+    const hit = svgEl("rect", {
+      class: "forest-row-hit",
+      x: 0,
+      y: y - ROW_HEIGHT / 2,
+      width: totalWidth,
+      height: ROW_HEIGHT,
+      fill: "transparent",
+    });
 
     const name = svgEl("text", { x: PAD_LEFT, y: y + 4, class: "forest-study" });
     name.textContent = study.study;
@@ -95,7 +206,15 @@ export function createForestPlotSvg(data: MetaAnalysisData = metaAnalysis): SVGS
     );
     const size = 3 + (study.weightPercent / maxWeight) * 8;
 
+    const effect = svgEl("text", {
+      x: forestX + FOREST_WIDTH + 8,
+      y: y + 4,
+      class: "forest-effect",
+    });
+    effect.textContent = `${formatRr(study.rr)} (${formatRr(study.ciLower)}–${formatRr(study.ciUpper)})`;
+
     row.append(
+      hit,
       name,
       n,
       svgEl("line", {
@@ -114,20 +233,26 @@ export function createForestPlotSvg(data: MetaAnalysisData = metaAnalysis): SVGS
         width: size,
         height: size,
         fill: study.color,
-      })
+      }),
+      effect
     );
 
-    const effect = svgEl("text", {
-      x: forestX + FOREST_WIDTH + 8,
-      y: y + 4,
-      class: "forest-effect",
+    const toggle = (e: Event) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (included.has(study.citationKey)) included.delete(study.citationKey);
+      else included.add(study.citationKey);
+      refresh();
+    };
+    row.addEventListener("click", toggle);
+    row.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") toggle(e);
     });
-    effect.textContent = `${formatRr(study.rr)} (${formatRr(study.ciLower)}–${formatRr(study.ciUpper)})`;
-    row.appendChild(effect);
+
+    rowEls.set(study.citationKey, row);
     svg.appendChild(row);
   });
 
-  const pooledY = PAD_TOP + data.studies.length * ROW_HEIGHT + ROW_HEIGHT / 2;
   const pooledRow = svgEl("g", { class: "forest-row forest-row--pooled" });
   const pooledName = svgEl("text", {
     x: PAD_LEFT,
@@ -135,31 +260,35 @@ export function createForestPlotSvg(data: MetaAnalysisData = metaAnalysis): SVGS
     class: "forest-study forest-study--pooled",
   });
   pooledName.textContent = data.pooled.label;
-
-  const px = logToX(data.pooled.logRr, data.logScaleXlim, forestX);
-  const pLo = Math.max(logToX(Math.log(data.pooled.ciLower), data.logScaleXlim, forestX), forestX);
-  const pHi = Math.min(
-    logToX(Math.log(data.pooled.ciUpper), data.logScaleXlim, forestX),
-    forestX + FOREST_WIDTH
-  );
-  const diamondH = 7;
-  pooledRow.append(
-    pooledName,
-    svgEl("polygon", {
-      class: "forest-diamond",
-      points: `${pLo},${pooledY} ${px},${pooledY - diamondH} ${pHi},${pooledY} ${px},${pooledY + diamondH}`,
-      fill: data.pooled.color,
-      stroke: "#12788f",
-      "stroke-width": 0.4,
-    })
-  );
+  const diamond = svgEl("polygon", {
+    class: "forest-diamond",
+    points: diamondPoints(
+      data.pooled.logRr,
+      data.pooled.ciLower,
+      data.pooled.ciUpper,
+      pooledY,
+      data.logScaleXlim,
+      forestX
+    ),
+    fill: data.pooled.color,
+    stroke: "#12788f",
+    "stroke-width": 0.4,
+  }) as SVGPolygonElement;
   const pooledEffect = svgEl("text", {
     x: forestX + FOREST_WIDTH + 8,
     y: pooledY + 4,
     class: "forest-effect forest-effect--pooled",
-  });
+  }) as SVGTextElement;
   pooledEffect.textContent = `${data.pooled.rrFormatted} (${data.pooled.ciFormatted.replace("; ", "–")})`;
-  pooledRow.appendChild(pooledEffect);
+  const emptyNote = svgEl("text", {
+    x: forestX + FOREST_WIDTH / 2,
+    y: pooledY + 4,
+    class: "forest-empty",
+    "text-anchor": "middle",
+  }) as SVGTextElement;
+  emptyNote.textContent = "Select at least one study";
+  emptyNote.style.display = "none";
+  pooledRow.append(pooledName, diamond, pooledEffect, emptyNote);
   svg.appendChild(pooledRow);
 
   const axisY = PAD_TOP + (data.studies.length + 1) * ROW_HEIGHT + 8;
@@ -209,5 +338,114 @@ export function createForestPlotSvg(data: MetaAnalysisData = metaAnalysis): SVGS
   rightLab.textContent = data.labels.right;
   svg.append(leftLab, rightLab);
 
-  return svg;
+  const chartWrap = document.createElement("div");
+  chartWrap.className = "forest-container";
+  chartWrap.setAttribute("data-animate", "");
+  chartWrap.appendChild(svg);
+  panel.appendChild(chartWrap);
+
+  const footer = document.createElement("p");
+  footer.className = "slide-footer forest-footer";
+  footer.setAttribute("data-animate", "");
+  panel.appendChild(footer);
+
+  function currentPooled(): PooledEstimate | null {
+    if (sameStudySet(included, allKeys)) {
+      return {
+        logRr: data.pooled.logRr,
+        seLogRr: data.pooled.seLogRr,
+        rr: data.pooled.rr,
+        ciLower: data.pooled.ciLower,
+        ciUpper: data.pooled.ciUpper,
+        rrFormatted: data.pooled.rrFormatted,
+        ciFormatted: data.pooled.ciFormatted,
+        i2: data.pooled.i2,
+        i2Rounded: data.pooled.i2Rounded,
+        tau2: data.pooled.tau2,
+        numberOfStudies: data.pooled.numberOfStudies,
+        q: 0,
+      };
+    }
+    const selected = data.studies.filter((s) => included.has(s.citationKey));
+    return poolRandomEffects(selected);
+  }
+
+  function syncChips(): void {
+    const chips = [...controls.querySelectorAll<HTMLButtonElement>(".forest-chip")];
+    for (const chip of chips) {
+      chip.classList.remove("is-active");
+    }
+    if (sameStudySet(included, allKeys)) {
+      allBtn.classList.add("is-active");
+      return;
+    }
+    for (const filter of DESIGN_FILTERS) {
+      const keys = data.studies.filter((s) => filter.match(s.design)).map((s) => s.citationKey);
+      if (keys.length > 0 && sameStudySet(included, keys)) {
+        const chip = chips.find((c) => c.dataset.filter === filter.label);
+        chip?.classList.add("is-active");
+        return;
+      }
+    }
+  }
+
+  function refresh(): void {
+    for (const study of data.studies) {
+      const row = rowEls.get(study.citationKey);
+      if (!row) continue;
+      const on = included.has(study.citationKey);
+      row.classList.toggle("is-excluded", !on);
+      row.setAttribute("aria-pressed", on ? "true" : "false");
+    }
+
+    const pooled = currentPooled();
+    if (!pooled) {
+      diamond.style.display = "none";
+      pooledEffect.style.display = "none";
+      emptyNote.style.display = "";
+      footer.textContent = "No studies selected — click a study to include it";
+      svg.setAttribute("aria-label", "Forest plot with no studies selected");
+    } else {
+      diamond.style.display = "";
+      pooledEffect.style.display = "";
+      emptyNote.style.display = "none";
+      diamond.setAttribute(
+        "points",
+        diamondPoints(
+          pooled.logRr,
+          pooled.ciLower,
+          pooled.ciUpper,
+          pooledY,
+          data.logScaleXlim,
+          forestX
+        )
+      );
+      pooledEffect.textContent = `${pooled.rrFormatted} (${pooled.ciFormatted.replace("; ", "–")})`;
+      footer.textContent = footerText(pooled, data.measure);
+      svg.setAttribute(
+        "aria-label",
+        `Forest plot of ATLS effect on mortality. Pooled risk ratio ${pooled.rrFormatted}, 95% CI ${pooled.ciFormatted}, ${pooled.numberOfStudies} studies`
+      );
+    }
+    syncChips();
+  }
+
+  function setIncluded(keys: Iterable<string>): void {
+    included.clear();
+    for (const key of keys) included.add(key);
+    refresh();
+  }
+
+  function includeAll(): void {
+    setIncluded(allKeys);
+  }
+
+  refresh();
+
+  return {
+    element: panel,
+    setIncluded,
+    includeAll,
+    getIncluded: () => new Set(included),
+  };
 }

--- a/presentations/atls-sweden-30-years/src/forest-plot.ts
+++ b/presentations/atls-sweden-30-years/src/forest-plot.ts
@@ -1,3 +1,4 @@
+import { animate } from "motion";
 import { metaAnalysis, type MetaAnalysisData } from "./figure-data";
 import { poolRandomEffects, sameStudySet, type PooledEstimate } from "./pool-meta";
 
@@ -72,6 +73,9 @@ export interface ForestPlotController {
   setIncluded(keys: Iterable<string>): void;
   includeAll(): void;
   getIncluded(): Set<string>;
+  /** Reveal studies oldest→newest, updating the pooled estimate after each. */
+  playChronologicalReveal(options?: { stepMs?: number }): Promise<void>;
+  abortReveal(): void;
 }
 
 /**
@@ -83,7 +87,10 @@ export interface ForestPlotController {
  */
 export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestPlotController {
   const allKeys = data.studies.map((s) => s.citationKey);
-  const included = new Set(allKeys);
+  // Start empty so the entrance reveal can build the pool chronologically.
+  const included = new Set<string>();
+  let revealToken = 0;
+  let revealing = false;
   const maxWeight = Math.max(...data.studies.map((s) => s.weightPercent));
   const forestX = PAD_LEFT + LABEL_WIDTH + N_WIDTH;
   const [xMin, xMax] = data.logScaleXlim;
@@ -101,14 +108,27 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
 
   const allBtn = document.createElement("button");
   allBtn.type = "button";
-  allBtn.className = "forest-chip is-active";
+  allBtn.className = "forest-chip";
   allBtn.textContent = "All studies";
   allBtn.dataset.filter = "all";
   allBtn.addEventListener("click", (e) => {
     e.stopPropagation();
+    abortReveal();
     includeAll();
   });
   controls.appendChild(allBtn);
+
+  const timelineBtn = document.createElement("button");
+  timelineBtn.type = "button";
+  timelineBtn.className = "forest-chip";
+  timelineBtn.dataset.filter = "timeline";
+  timelineBtn.textContent = "Play timeline";
+  timelineBtn.title = "Add studies in chronological order and watch the pooled estimate change";
+  timelineBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    void playChronologicalReveal();
+  });
+  controls.appendChild(timelineBtn);
 
   for (const filter of DESIGN_FILTERS) {
     const keys = data.studies.filter((s) => filter.match(s.design)).map((s) => s.citationKey);
@@ -121,6 +141,7 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
     btn.title = `Include only ${filter.label.toLowerCase()} studies`;
     btn.addEventListener("click", (e) => {
       e.stopPropagation();
+      abortReveal();
       setIncluded(keys);
     });
     controls.appendChild(btn);
@@ -240,6 +261,7 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
     const toggle = (e: Event) => {
       e.stopPropagation();
       e.preventDefault();
+      abortReveal();
       if (included.has(study.citationKey)) included.delete(study.citationKey);
       else included.add(study.citationKey);
       refresh();
@@ -375,6 +397,10 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
     for (const chip of chips) {
       chip.classList.remove("is-active");
     }
+    if (revealing) {
+      timelineBtn.classList.add("is-active");
+      return;
+    }
     if (sameStudySet(included, allKeys)) {
       allBtn.classList.add("is-active");
       return;
@@ -403,7 +429,12 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
       diamond.style.display = "none";
       pooledEffect.style.display = "none";
       emptyNote.style.display = "";
-      footer.textContent = "No studies selected — click a study to include it";
+      emptyNote.textContent = revealing
+        ? "Adding studies chronologically…"
+        : "Select at least one study";
+      footer.textContent = revealing
+        ? "Building the pooled estimate as studies appear (oldest → newest)"
+        : "No studies selected — click a study to include it";
       svg.setAttribute("aria-label", "Forest plot with no studies selected");
     } else {
       diamond.style.display = "";
@@ -420,6 +451,10 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
           forestX
         )
       );
+      diamond.classList.remove("is-updating");
+      // Force reflow so the pulse can replay on each update.
+      void diamond.getBoundingClientRect();
+      diamond.classList.add("is-updating");
       pooledEffect.textContent = `${pooled.rrFormatted} (${pooled.ciFormatted.replace("; ", "–")})`;
       footer.textContent = footerText(pooled, data.measure);
       svg.setAttribute(
@@ -430,7 +465,66 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
     syncChips();
   }
 
+  function abortReveal(): void {
+    revealToken += 1;
+    revealing = false;
+    panel.classList.remove("is-revealing");
+    timelineBtn.disabled = false;
+  }
+
+  function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      window.setTimeout(resolve, ms);
+    });
+  }
+
+  async function playChronologicalReveal(options: { stepMs?: number } = {}): Promise<void> {
+    const stepMs = options.stepMs ?? 420;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      includeAll();
+      return;
+    }
+
+    const token = ++revealToken;
+    revealing = true;
+    panel.classList.add("is-revealing");
+    timelineBtn.disabled = true;
+    included.clear();
+    refresh();
+    await delay(280);
+    if (token !== revealToken) return;
+
+    // Studies are already ordered by year in the R export.
+    for (const study of data.studies) {
+      if (token !== revealToken) return;
+      included.add(study.citationKey);
+      refresh();
+
+      const row = rowEls.get(study.citationKey);
+      if (row) {
+        row.style.opacity = "0";
+        await animate(
+          row,
+          { opacity: [0, 1] } as Record<string, unknown>,
+          { duration: 0.32, ease: "easeOut" }
+        );
+        row.style.opacity = "";
+      }
+
+      await delay(stepMs);
+      if (token !== revealToken) return;
+    }
+
+    if (token !== revealToken) return;
+    revealing = false;
+    panel.classList.remove("is-revealing");
+    timelineBtn.disabled = false;
+    // Final paint uses the R-exported REML pooled estimate.
+    refresh();
+  }
+
   function setIncluded(keys: Iterable<string>): void {
+    abortReveal();
     included.clear();
     for (const key of keys) included.add(key);
     refresh();
@@ -447,5 +541,7 @@ export function createForestPlot(data: MetaAnalysisData = metaAnalysis): ForestP
     setIncluded,
     includeAll,
     getIncluded: () => new Set(included),
+    playChronologicalReveal,
+    abortReveal,
   };
 }

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -1,8 +1,7 @@
 import { animate, stagger } from "motion";
 import { slides, type Slide } from "./slides";
 import { createSteppedWedgeSvg } from "./stepped-wedge";
-import { createForestPlotSvg } from "./forest-plot";
-import { metaAnalysis } from "./figure-data";
+import { createForestPlot } from "./forest-plot";
 import "./style.css";
 
 let currentIndex = 0;
@@ -280,22 +279,14 @@ function renderSlide(slide: Slide): HTMLElement {
       `;
       break;
 
-    case "forest": {
-      const pooled = metaAnalysis.pooled;
+    case "forest":
       el.innerHTML = `
         <div class="slide-inner">
           <h2 data-animate>${slide.title}</h2>
-          <div class="forest-container" data-animate id="forest-mount"></div>
-          <p class="slide-footer" data-animate>
-            Random-effects ${metaAnalysis.measure} ${pooled.rrFormatted}
-            (95% CI ${pooled.ciFormatted.replace("; ", "–")});
-            I² ${pooled.i2Rounded.toFixed(2)};
-            ${pooled.numberOfStudies} observational studies
-          </p>
+          <div id="forest-mount"></div>
         </div>
       `;
       break;
-    }
 
     case "implications":
       el.innerHTML = `
@@ -333,7 +324,7 @@ function mountSlides(): void {
     }
     if (slide.layout === "forest") {
       const mount = el.querySelector("#forest-mount");
-      if (mount) mount.appendChild(createForestPlotSvg());
+      if (mount) mount.appendChild(createForestPlot().element);
     }
   });
 }

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -1,11 +1,12 @@
 import { animate, stagger } from "motion";
 import { slides, type Slide } from "./slides";
 import { createSteppedWedgeSvg } from "./stepped-wedge";
-import { createForestPlot } from "./forest-plot";
+import { createForestPlot, type ForestPlotController } from "./forest-plot";
 import "./style.css";
 
 let currentIndex = 0;
 let isAnimating = false;
+const forestControllers = new WeakMap<HTMLElement, ForestPlotController>();
 
 const slidesEl = document.getElementById("slides")!;
 const counterEl = document.getElementById("slide-counter")!;
@@ -324,7 +325,11 @@ function mountSlides(): void {
     }
     if (slide.layout === "forest") {
       const mount = el.querySelector("#forest-mount");
-      if (mount) mount.appendChild(createForestPlot().element);
+      if (mount) {
+        const forest = createForestPlot();
+        mount.appendChild(forest.element);
+        forestControllers.set(el, forest);
+      }
     }
   });
 }
@@ -370,12 +375,10 @@ function animateSlideIn(slideEl: HTMLElement): void {
   }
 
   if (slideEl.dataset.layout === "forest") {
-    const rows = Array.from(slideEl.querySelectorAll<HTMLElement>(".forest-row"));
-    animate(
-      rows,
-      { opacity: [0, 1], transform: ["translateX(-12px)", "translateX(0)"] } as Record<string, unknown>,
-      { duration: 0.35, delay: stagger(0.04, { startDelay: 0.25 }), ease: "easeOut" }
-    );
+    const forest = forestControllers.get(slideEl);
+    if (forest) {
+      void forest.playChronologicalReveal();
+    }
   }
 
   const img = slideEl.querySelector<HTMLElement>(".slide-figure img, .visual-figure img");
@@ -394,6 +397,7 @@ function goTo(index: number): void {
 
   const current = slidesEl.children[currentIndex] as HTMLElement;
   const next = slidesEl.children[index] as HTMLElement;
+  forestControllers.get(current)?.abortReveal();
 
   animate(
     current,

--- a/presentations/atls-sweden-30-years/src/pool-meta.ts
+++ b/presentations/atls-sweden-30-years/src/pool-meta.ts
@@ -1,0 +1,91 @@
+import type { MetaAnalysisStudy } from "./figure-data";
+
+export interface PooledEstimate {
+  logRr: number;
+  seLogRr: number;
+  rr: number;
+  ciLower: number;
+  ciUpper: number;
+  rrFormatted: string;
+  ciFormatted: string;
+  i2: number;
+  i2Rounded: number;
+  tau2: number;
+  numberOfStudies: number;
+  q: number;
+}
+
+function formatRr(value: number): string {
+  return value.toFixed(2);
+}
+
+/**
+ * Inverse-variance random-effects pool (DerSimonian–Laird τ²).
+ * Study-level logRr / seLogRr come from the R metabin export.
+ */
+export function poolRandomEffects(
+  studies: Pick<MetaAnalysisStudy, "logRr" | "seLogRr">[]
+): PooledEstimate | null {
+  if (studies.length === 0) return null;
+  if (studies.length === 1) {
+    const s = studies[0];
+    const rr = Math.exp(s.logRr);
+    const ciLower = Math.exp(s.logRr - 1.96 * s.seLogRr);
+    const ciUpper = Math.exp(s.logRr + 1.96 * s.seLogRr);
+    return {
+      logRr: s.logRr,
+      seLogRr: s.seLogRr,
+      rr,
+      ciLower,
+      ciUpper,
+      rrFormatted: formatRr(rr),
+      ciFormatted: `${formatRr(ciLower)}; ${formatRr(ciUpper)}`,
+      i2: 0,
+      i2Rounded: 0,
+      tau2: 0,
+      numberOfStudies: 1,
+      q: 0,
+    };
+  }
+
+  const yi = studies.map((s) => s.logRr);
+  const vi = studies.map((s) => s.seLogRr ** 2);
+  const wi = vi.map((v) => 1 / v);
+  const sumW = wi.reduce((a, b) => a + b, 0);
+  const teFixed = wi.reduce((acc, w, i) => acc + w * yi[i], 0) / sumW;
+  const q = wi.reduce((acc, w, i) => acc + w * (yi[i] - teFixed) ** 2, 0);
+  const k = studies.length;
+  const df = k - 1;
+  const c = sumW - wi.reduce((acc, w) => acc + w * w, 0) / sumW;
+  const tau2 = Math.max(0, (q - df) / c);
+  const wr = vi.map((v) => 1 / (v + tau2));
+  const sumWr = wr.reduce((a, b) => a + b, 0);
+  const logRr = wr.reduce((acc, w, i) => acc + w * yi[i], 0) / sumWr;
+  const seLogRr = Math.sqrt(1 / sumWr);
+  const rr = Math.exp(logRr);
+  const ciLower = Math.exp(logRr - 1.96 * seLogRr);
+  const ciUpper = Math.exp(logRr + 1.96 * seLogRr);
+  const i2 = q > 0 ? Math.max(0, (q - df) / q) : 0;
+
+  return {
+    logRr,
+    seLogRr,
+    rr,
+    ciLower,
+    ciUpper,
+    rrFormatted: formatRr(rr),
+    ciFormatted: `${formatRr(ciLower)}; ${formatRr(ciUpper)}`,
+    i2,
+    i2Rounded: Math.round(i2 * 100) / 100,
+    tau2,
+    numberOfStudies: k,
+    q,
+  };
+}
+
+export function sameStudySet(
+  included: ReadonlySet<string>,
+  allKeys: readonly string[]
+): boolean {
+  return allKeys.length === included.size && allKeys.every((key) => included.has(key));
+}

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -255,7 +255,6 @@ export const slides: Slide[] = [
       },
     ],
   },
-<<<<<<< HEAD
   {
     id: "atls-forest",
     layout: "forest",
@@ -274,21 +273,6 @@ export const slides: Slide[] = [
     ],
     cite: "Shilston & Turner 2022; Wiles 2015",
   },
-=======
-  // {
-  //   id: "atls-critique",
-  //   layout: "bullets",
-  //   title: "Critique",
-  //   bullets: [
-  //     "Costly",
-  //     "Perpetuates theories despite evidence of the contrary",
-  //     "Not adapted to modern trauma care",
-  //     "Not adaptable to local circumstances",
-  //     "Fixed didactic nature",
-  //   ],
-  //   cite: "Shilston & Turner 2022; Wiles 2015",
-  // },
->>>>>>> main
   {
     id: "section-trial",
     layout: "section",

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -798,7 +798,7 @@ body {
 }
 
 .forest-container {
-  margin-top: 0.6rem;
+  margin-top: 0.35rem;
   background: var(--surface-muted);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -806,10 +806,58 @@ body {
   overflow: hidden;
 }
 
+.forest-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-top: 0.35rem;
+}
+
+.forest-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.55rem;
+}
+
+.forest-chip {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.38rem 0.65rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.forest-chip:hover {
+  border-color: var(--brand);
+  color: var(--brand-darker);
+}
+
+.forest-chip.is-active {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: var(--text-inverse);
+}
+
+.forest-hint {
+  margin-left: auto;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.forest-footer {
+  margin-top: 0.15rem;
+}
+
 .forest-plot-chart {
   width: 100%;
   height: auto;
-  max-height: min(62vh, 520px);
+  max-height: min(58vh, 500px);
 }
 
 .forest-plot-chart .forest-header,
@@ -824,10 +872,27 @@ body {
 .forest-plot-chart .forest-study,
 .forest-plot-chart .forest-n,
 .forest-plot-chart .forest-effect,
-.forest-plot-chart .axis-label {
+.forest-plot-chart .axis-label,
+.forest-plot-chart .forest-empty {
   font-family: var(--font-body);
   font-size: 8.5px;
   fill: var(--text);
+}
+
+.forest-row--interactive {
+  cursor: pointer;
+}
+
+.forest-row--interactive:hover .forest-row-hit {
+  fill: rgba(26, 157, 187, 0.08);
+}
+
+.forest-row.is-excluded {
+  opacity: 0.28;
+}
+
+.forest-row.is-excluded .forest-study {
+  text-decoration: line-through;
 }
 
 .forest-square,

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -850,6 +850,29 @@ body {
   color: var(--text-muted);
 }
 
+.forest-panel.is-revealing .forest-row.is-excluded {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.forest-panel.is-revealing .forest-chip:not([data-filter="timeline"]) {
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.forest-diamond.is-updating {
+  animation: forest-diamond-pulse 0.45s ease-out;
+}
+
+@keyframes forest-diamond-pulse {
+  0% {
+    opacity: 0.35;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
 .forest-footer {
   margin-top: 0.15rem;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Makes the `#atls-forest` slide interactive so the pooled estimate updates when the included studies change.

**Chronological reveal**
- On slide enter, studies appear oldest → newest
- The pooled diamond, CI, and I² update after each study
- **Play timeline** chip replays the animation
- Respects `prefers-reduced-motion` (jumps to the full set)

**Manual interaction**
- Click a study row to include or exclude it
- Chips: **All studies**, **Prospective**, **Retrospective**, **Registry**

**Pooling**
- Full study set: R-exported REML pooled estimate (protocol-aligned)
- Subsets: inverse-variance DerSimonian–Laird in `src/pool-meta.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c118374-66f2-429e-99e4-3a3bf4d15f51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c118374-66f2-429e-99e4-3a3bf4d15f51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

