### PR TITLE
Add clinical-impact review slides to ATLS Sweden presentation

### DIFF
--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -40,9 +40,11 @@ Image assets in `public/` are copied to `dist/` during build:
 |---|-----|---------|
 | 1 | `title` | Title slide |
 | 2–3 | `section-problem`, `trauma-stats` | Trauma burden |
-| 4–11 | ATLS slides | Purpose, evidence, critique |
+| 4–12 | ATLS slides | Purpose, evidence, critique |
 | — | `atls-impact-sources` | Historical sources for manual Impact claims |
-| 12–21 | Trial slides | Design, outcomes, status |
+| — | `atls-outcomes-reviews` | Systematic reviews on patient outcomes |
+| — | `atls-outcomes-scoping` | Scoping reviews on patient outcomes |
+| 13–22 | Trial slides | Design, outcomes, status |
 | 21–22 | `implications`, `closing` | Take-home messages |
 
 ## Source

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -120,6 +120,7 @@ function renderSlide(slide: Slide): HTMLElement {
             ${(slide.bullets ?? []).map((b) => `<li data-animate>${b}</li>`).join("")}
           </ul>
           ${slide.cite ? `<p class="cite-line" data-animate>${slide.cite}</p>` : ""}
+          ${slide.footer ? `<p class="slide-footer" data-animate>${slide.footer}</p>` : ""}
         </div>
       `;
       break;

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -175,14 +175,28 @@ export const slides: Slide[] = [
   {
     id: "atls-outcomes-reviews",
     layout: "bullets",
-    title: "Evidence on patient outcomes",
+    title: "Evidence on patient outcomes — systematic reviews",
     bullets: [
-      "Mohammad et al. 2013 — future studies required to evaluate impact on trauma death rates",
-      "Jayaraman et al. 2014 — no evidence from controlled trials that ATLS impacts outcomes",
-      "Jin et al. 2021 — in-hospital trauma training reduced mortality (RR 0.71, 95% CI 0.62–0.78)",
-      "Putra et al. 2023 — ATLS had no significant effect on mortality (OR 0.68, 95% CI 0.39–1.20)",
-      "Nakhid et al. 2026 — 10 observational studies; pooled OR 0.51",
+      "Mohammad et al. 2013 — educational impact established; strong evidence that ATLS reduces mortality still lacking",
+      "Jayaraman et al. 2014 (Cochrane) — no controlled-trial evidence that ATLS changes mortality or morbidity",
+      "Jin et al. 2021 — certified in-hospital trauma training associated with lower mortality (RR 0.71, 95% CI 0.62–0.78)",
+      "Putra et al. 2023 — ATLS not significantly associated with lower mortality (OR 0.68, 95% CI 0.39–1.20)",
+      "Nakhid et al. 2026 — trauma life support training associated with lower mortality (OR 0.60, 95% CI 0.48–0.75); all observational",
     ],
+  },
+  {
+    id: "atls-outcomes-scoping",
+    layout: "bullets",
+    title: "Evidence on patient outcomes — scoping reviews",
+    bullets: [
+      "Livergant et al. 2021 — only 3 of 45 LMIC course studies assessed patient outcomes; 2 found no improvement",
+      "Brown et al. 2022 — among ATLS alternatives, only one study reported a mortality reduction",
+      "Nelson et al. 2026 — 3 of 14 ED-physician studies assessed clinical impact; results mixed",
+      "Hauta et al. 2024 — team performance often improves; mortality, morbidity and length of stay generally do not",
+      "Petroze 2014 / Osebo 2025 — patient-outcome data for focused LMIC trauma courses remain scarce",
+    ],
+    footer:
+      "Across reviews: knowledge and skills improve; randomised evidence that training changes patient outcomes is still missing.",
   },
   {
     id: "atls-critique",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Expanded the ATLS Sweden 30-year deck’s patient-outcomes evidence into two slides focused on **clinical impact** (mortality, morbidity, length of stay).
- Systematic-review slide covers Mohammad, Jayaraman (Cochrane), Jin, Putra, and Nakhid (corrected pooled OR to 0.60).
- New scoping-review slide covers Livergant, Brown, Nelson, Hauta, and Petroze/Osebo, with a takeaway footer that educational gains are clearer than patient-outcome evidence.
- Bullets layout now renders optional footers so that takeaway is visible.

## Test plan
- [x] `pnpm build` succeeds for the presentation
- [x] Previewed `#atls-outcomes-reviews` and `#atls-outcomes-scoping` in the browser
- [x] Screenshots of both slides attached as walkthrough artifacts

[Systematic reviews slide](https://cursor.com/agents/bc-686296c0-48bd-4eba-b1ac-d4039d0fe3a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fatls-outcomes-systematic-reviews.webp)
[Scoping reviews slide with footer](https://cursor.com/agents/bc-686296c0-48bd-4eba-b1ac-d4039d0fe3a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fatls-outcomes-scoping-reviews-with-footer.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-686296c0-48bd-4eba-b1ac-d4039d0fe3a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-686296c0-48bd-4eba-b1ac-d4039d0fe3a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

