### PR TITLE
Add sequences randomisation slide to ATLS Sweden 30-year presentation

### DIFF
--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -28,7 +28,7 @@ Image assets in `public/` are copied to `dist/` during build:
 
 ## Features
 
-- **Motion** animations — staggered entrance, forest plot and stepped-wedge reveal
+- **Motion** animations — staggered entrance, forest plot, sequence randomisation, and stepped-wedge reveal
 - **Deep linking** — each slide has a URL hash (e.g. `#design`)
 - **Responsive** — works on projectors, laptops, and tablets
 - **Accessible** — keyboard navigation, ARIA labels, reduced-motion support
@@ -43,7 +43,7 @@ Image assets in `public/` are copied to `dist/` during build:
 | 4–12 | ATLS slides | Purpose, evidence, forest plot, critique |
 | — | `atls-impact-sources` | Historical sources for manual Impact claims |
 | — | `atls-forest` | Updated systematic review forest plot |
-| 12–21 | Trial slides | Design, nested staircase, outcomes, status |
+| 12–22 | Trial slides | Design, sequences, nested staircase, outcomes, status |
 | 21–22 | `implications`, `closing` | Take-home messages |
 
 ## Source

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -336,10 +336,9 @@ function renderSlide(slide: Slide): HTMLElement {
       el.innerHTML = `
         <div class="slide-inner slide-inner--sequences">
           <h2 data-animate>${slide.title}</h2>
-          ${slide.body ? `<p class="sequences-lead" data-animate>${slide.body}</p>` : ""}
-          <div class="sequences-panel" data-animate>
-            <div class="sequences-legend-mount"></div>
+          <div class="sequences-panel">
             <div class="sequences-mount" id="sequences-mount"></div>
+            <div class="sequences-legend-mount" data-animate></div>
           </div>
         </div>
       `;
@@ -406,7 +405,7 @@ function mountSlides(): void {
       const mount = el.querySelector("#sequences-mount");
       const legendMount = el.querySelector(".sequences-legend-mount");
       if (mount) mount.appendChild(createSequencesChart(trialDesign));
-      if (legendMount) legendMount.appendChild(createSequencesLegend(trialDesign));
+      if (legendMount) legendMount.appendChild(createSequencesLegend());
     }
     if (slide.layout === "forest") {
       const mount = el.querySelector("#forest-mount");
@@ -481,25 +480,32 @@ function animateSlideIn(slideEl: HTMLElement): void {
   }
 
   if (slideEl.dataset.layout === "sequences") {
-    const rows = Array.from(slideEl.querySelectorAll<HTMLElement>(".sequence-row"));
-    const bars = Array.from(slideEl.querySelectorAll<HTMLElement>(".sequence-bar"));
-    rows.forEach((row) => {
-      row.style.transformOrigin = "left center";
-    });
-    animate(
-      rows,
-      { opacity: [0, 1], transform: ["translateY(16px)", "translateY(0)"] } as Record<string, unknown>,
-      { duration: 0.45, delay: stagger(0.12, { startDelay: 0.2 }), ease: [0.22, 1, 0.36, 1] }
+    const flowParts = Array.from(
+      slideEl.querySelectorAll<HTMLElement>(
+        ".consort-flow__assessed, .consort-flow__mid, .consort-flow__randomised, .consort-flow__sequences"
+      )
     );
-    bars.forEach((bar) => {
-      bar.style.transformOrigin = "left center";
+    animate(
+      flowParts,
+      { opacity: [0, 1], transform: ["translateY(18px)", "translateY(0)"] } as Record<string, unknown>,
+      { duration: 0.45, delay: stagger(0.14, { startDelay: 0.15 }), ease: [0.22, 1, 0.36, 1] }
+    );
+    const cols = Array.from(slideEl.querySelectorAll<HTMLElement>(".consort-sequence"));
+    animate(
+      cols,
+      { opacity: [0, 1], transform: ["translateY(12px)", "translateY(0)"] } as Record<string, unknown>,
+      { duration: 0.4, delay: stagger(0.08, { startDelay: 0.55 }), ease: [0.22, 1, 0.36, 1] }
+    );
+    const cells = Array.from(slideEl.querySelectorAll<HTMLElement>(".consort-cell"));
+    cells.forEach((cell) => {
+      cell.style.transformOrigin = "left center";
     });
     animate(
-      bars,
+      cells,
       { transform: ["scaleX(0)", "scaleX(1)"] } as Record<string, unknown>,
       {
-        duration: 0.55,
-        delay: stagger(0.04, { startDelay: 0.28 }),
+        duration: 0.35,
+        delay: stagger(0.012, { startDelay: 0.7 }),
         ease: [0.22, 1, 0.36, 1],
       }
     );

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -3,6 +3,7 @@ import { slides, type Slide } from "./slides";
 import { createSteppedWedgeSvg, setRevealMonth, focusViewBox, viewBoxString, syncAxisToStage } from "./stepped-wedge";
 import { createForestPlotSvg } from "./forest-plot";
 import { designRevealStageMeta, startDesignReveal, type DesignRevealControls } from "./design-reveal";
+import { createSequencesChart, createSequencesLegend } from "./sequences";
 import { metaAnalysis, trialDesign, trialDesignStaircase } from "./figure-data";
 import "./style.css";
 
@@ -331,6 +332,19 @@ function renderSlide(slide: Slide): HTMLElement {
       break;
     }
 
+    case "sequences":
+      el.innerHTML = `
+        <div class="slide-inner slide-inner--sequences">
+          <h2 data-animate>${slide.title}</h2>
+          ${slide.body ? `<p class="sequences-lead" data-animate>${slide.body}</p>` : ""}
+          <div class="sequences-panel" data-animate>
+            <div class="sequences-legend-mount"></div>
+            <div class="sequences-mount" id="sequences-mount"></div>
+          </div>
+        </div>
+      `;
+      break;
+
     case "forest": {
       const pooled = metaAnalysis.pooled;
       el.innerHTML = `
@@ -387,6 +401,12 @@ function mountSlides(): void {
         }
         // design-animation chart is mounted by startDesignReveal.
       }
+    }
+    if (slide.layout === "sequences") {
+      const mount = el.querySelector("#sequences-mount");
+      const legendMount = el.querySelector(".sequences-legend-mount");
+      if (mount) mount.appendChild(createSequencesChart(trialDesign));
+      if (legendMount) legendMount.appendChild(createSequencesLegend(trialDesign));
     }
     if (slide.layout === "forest") {
       const mount = el.querySelector("#forest-mount");
@@ -458,6 +478,31 @@ function animateSlideIn(slideEl: HTMLElement): void {
   } else {
     designReveal?.cancel();
     designReveal = null;
+  }
+
+  if (slideEl.dataset.layout === "sequences") {
+    const rows = Array.from(slideEl.querySelectorAll<HTMLElement>(".sequence-row"));
+    const bars = Array.from(slideEl.querySelectorAll<HTMLElement>(".sequence-bar"));
+    rows.forEach((row) => {
+      row.style.transformOrigin = "left center";
+    });
+    animate(
+      rows,
+      { opacity: [0, 1], transform: ["translateY(16px)", "translateY(0)"] } as Record<string, unknown>,
+      { duration: 0.45, delay: stagger(0.12, { startDelay: 0.2 }), ease: [0.22, 1, 0.36, 1] }
+    );
+    bars.forEach((bar) => {
+      bar.style.transformOrigin = "left center";
+    });
+    animate(
+      bars,
+      { transform: ["scaleX(0)", "scaleX(1)"] } as Record<string, unknown>,
+      {
+        duration: 0.55,
+        delay: stagger(0.04, { startDelay: 0.28 }),
+        ease: [0.22, 1, 0.36, 1],
+      }
+    );
   }
 
   if (slideEl.dataset.layout === "forest") {

--- a/presentations/atls-sweden-30-years/src/sequences.ts
+++ b/presentations/atls-sweden-30-years/src/sequences.ts
@@ -1,0 +1,159 @@
+import { trialDesign, type TrialDesignData } from "./figure-data";
+
+export interface SequencePhase {
+  phase: string;
+  months: number;
+  start: number;
+  end: number;
+}
+
+export interface ImplementationSequence {
+  sequence: number;
+  phases: SequencePhase[];
+  totalMonths: number;
+}
+
+const PHASE_ORDER = ["Standard care", "Transition", "Intervention"] as const;
+
+export function implementationSequences(
+  data: TrialDesignData = trialDesign,
+  batch = 1
+): ImplementationSequence[] {
+  const segments = data.segments.filter((s) => s.batch === batch && s.layer === "main");
+  const ids = [...new Set(segments.map((s) => s.sequence))].sort((a, b) => a - b);
+
+  return ids.map((sequence) => {
+    const ofSeq = segments.filter((s) => s.sequence === sequence);
+    const phases: SequencePhase[] = PHASE_ORDER.map((phase) => {
+      const seg = ofSeq.find((s) => s.phase === phase);
+      if (!seg) {
+        throw new Error(`Missing ${phase} for sequence ${sequence} in batch ${batch}`);
+      }
+      return {
+        phase,
+        months: seg.end - seg.start,
+        start: seg.start,
+        end: seg.end,
+      };
+    });
+    const last = phases[phases.length - 1];
+    return {
+      sequence,
+      phases,
+      totalMonths: last.end,
+    };
+  });
+}
+
+function monthsLabel(n: number): string {
+  return n === 1 ? "1 month" : `${n} months`;
+}
+
+function phaseClass(phase: string): string {
+  return phase.toLowerCase().replace(/\s+/g, "-");
+}
+
+function barLabel(phase: SequencePhase): string {
+  if (phase.phase === "Transition") return "ATLS®";
+  return monthsLabel(phase.months);
+}
+
+export function createSequencesChart(data: TrialDesignData = trialDesign): HTMLElement {
+  const sequences = implementationSequences(data);
+  const totalMonths = sequences[0]?.totalMonths ?? data.parameters.totalMonths;
+  const chart = document.createElement("div");
+  chart.className = "sequences-chart";
+  chart.setAttribute(
+    "aria-label",
+    `Five implementation sequences. Sequence 1 has ${sequences[0]?.phases[0]?.months} months of standard care, training, then ${sequences[0]?.phases[2]?.months} months of intervention. Each later sequence adds one month of standard care and one fewer month of intervention.`
+  );
+
+  const axis = document.createElement("div");
+  axis.className = "sequences-axis";
+  axis.setAttribute("aria-hidden", "true");
+  const axisSpacer = document.createElement("span");
+  axisSpacer.className = "sequences-axis__label";
+  axis.appendChild(axisSpacer);
+
+  const ticks = document.createElement("div");
+  ticks.className = "sequences-axis__ticks";
+  const tickStep = 2;
+  for (let month = 0; month <= totalMonths; month += tickStep) {
+    const tick = document.createElement("span");
+    tick.className = "sequences-axis__tick";
+    tick.style.left = `${(month / totalMonths) * 100}%`;
+    tick.textContent = String(month);
+    ticks.appendChild(tick);
+  }
+  if (totalMonths % tickStep !== 0) {
+    const endTick = document.createElement("span");
+    endTick.className = "sequences-axis__tick sequences-axis__tick--end";
+    endTick.style.left = "100%";
+    endTick.textContent = String(totalMonths);
+    ticks.appendChild(endTick);
+  }
+  axis.appendChild(ticks);
+  chart.appendChild(axis);
+
+  const rows = document.createElement("div");
+  rows.className = "sequences-rows";
+
+  for (const seq of sequences) {
+    const row = document.createElement("div");
+    row.className = "sequence-row";
+    row.dataset.sequence = String(seq.sequence);
+
+    const label = document.createElement("p");
+    label.className = "sequence-row__label";
+    label.textContent = `Sequence ${seq.sequence}`;
+    row.appendChild(label);
+
+    const track = document.createElement("div");
+    track.className = "sequence-row__track";
+    track.style.gridTemplateColumns = `repeat(${totalMonths}, minmax(0, 1fr))`;
+
+    for (const phase of seq.phases) {
+      const bar = document.createElement("div");
+      bar.className = `sequence-bar sequence-bar--${phaseClass(phase.phase)}`;
+      bar.style.gridColumn = `${phase.start + 1} / ${phase.end + 1}`;
+      bar.style.background = data.colors[phase.phase] ?? "#999999";
+      bar.title = `${phase.phase}: ${monthsLabel(phase.months)}`;
+      const text = document.createElement("span");
+      text.className = "sequence-bar__text";
+      text.textContent = barLabel(phase);
+      bar.appendChild(text);
+      track.appendChild(bar);
+    }
+
+    row.appendChild(track);
+    rows.appendChild(row);
+  }
+
+  chart.appendChild(rows);
+
+  const axisTitle = document.createElement("p");
+  axisTitle.className = "sequences-axis-title";
+  axisTitle.textContent = "Study month";
+  chart.appendChild(axisTitle);
+
+  return chart;
+}
+
+export function createSequencesLegend(data: TrialDesignData = trialDesign): HTMLElement {
+  const el = document.createElement("div");
+  el.className = "wedge-legend sequences-legend";
+  el.setAttribute("aria-hidden", "true");
+  for (const phase of data.legend) {
+    const item = document.createElement("span");
+    item.className = "wedge-legend__item";
+    const swatch = document.createElement("span");
+    swatch.className = "wedge-legend__swatch";
+    swatch.style.background = data.colors[phase] ?? "#999999";
+    const label = document.createElement("span");
+    label.className = "wedge-legend__label";
+    label.textContent = phase === "Transition" ? "Training (1 month)" : phase;
+    item.append(swatch, label);
+    el.appendChild(item);
+  }
+  return el;
+}

--- a/presentations/atls-sweden-30-years/src/sequences.ts
+++ b/presentations/atls-sweden-30-years/src/sequences.ts
@@ -23,6 +23,7 @@ const STRIP_COLORS: Record<string, string> = {
 };
 
 const BOX_FILL = "#FCCE94";
+const LINE = "#6b7a80";
 
 export function implementationSequences(
   data: TrialDesignData = trialDesign,
@@ -66,6 +67,14 @@ function monthPhases(seq: ImplementationSequence): string[] {
   return months;
 }
 
+function svgEl(tag: string, attrs: Record<string, string | number> = {}): SVGElement {
+  const el = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    el.setAttribute(key, String(value));
+  }
+  return el;
+}
+
 function flowBox(text: string, kind: "primary" | "side" = "primary"): HTMLElement {
   const box = document.createElement("div");
   box.className = `consort-box consort-box--${kind}`;
@@ -100,11 +109,6 @@ function sequenceColumn(seq: ImplementationSequence, totalMonths: number): HTMLE
   col.className = "consort-sequence";
   col.dataset.sequence = String(seq.sequence);
 
-  const drop = document.createElement("div");
-  drop.className = "consort-sequence__drop";
-  drop.setAttribute("aria-hidden", "true");
-  col.appendChild(drop);
-
   const title = document.createElement("p");
   title.className = "consort-sequence__title";
   title.textContent = `Sequence ${seq.sequence}`;
@@ -130,6 +134,120 @@ function sequenceColumn(seq: ImplementationSequence, totalMonths: number): HTMLE
   return col;
 }
 
+/** Mid stem with side branch + arrow into the exclusion box (SVG for continuous joins). */
+function createMidConnectors(): SVGSVGElement {
+  const w = 200;
+  const h = 160;
+  const cx = 20;
+  const midY = h / 2;
+  const branchEnd = 78;
+  const svg = svgEl("svg", {
+    class: "consort-mid-svg",
+    viewBox: `0 0 ${w} ${h}`,
+    preserveAspectRatio: "none",
+    "aria-hidden": "true",
+  }) as SVGSVGElement;
+
+  svg.appendChild(
+    svgEl("line", {
+      x1: cx,
+      y1: 0,
+      x2: cx,
+      y2: h,
+      stroke: LINE,
+      "stroke-width": 2,
+    })
+  );
+  svg.appendChild(
+    svgEl("line", {
+      x1: cx,
+      y1: midY,
+      x2: branchEnd,
+      y2: midY,
+      stroke: LINE,
+      "stroke-width": 2,
+    })
+  );
+  // Arrowhead flush with branch tip
+  svg.appendChild(
+    svgEl("polygon", {
+      points: `${branchEnd - 1},${midY - 6} ${branchEnd + 10},${midY} ${branchEnd - 1},${midY + 6}`,
+      fill: LINE,
+    })
+  );
+  return svg;
+}
+
+/** Fan from randomised box into sequence columns (SVG for continuous T-junctions). */
+function createFanSvg(nSeq: number): SVGSVGElement {
+  const w = 1000;
+  const stemH = 28;
+  const dropH = 36;
+  const h = stemH + dropH;
+  const colW = w / nSeq;
+  const railY = stemH;
+  const arrowH = 10;
+  const arrowHalf = 6;
+  const tipY = h - 1;
+
+  const svg = svgEl("svg", {
+    class: "consort-fan-svg",
+    viewBox: `0 0 ${w} ${h}`,
+    preserveAspectRatio: "none",
+    "aria-hidden": "true",
+  }) as SVGSVGElement;
+
+  // Stem from randomised (centre) down to rail
+  svg.appendChild(
+    svgEl("line", {
+      x1: w / 2,
+      y1: 0,
+      x2: w / 2,
+      y2: railY,
+      stroke: LINE,
+      "stroke-width": 2,
+    })
+  );
+
+  // Horizontal rail across column centres
+  const x0 = colW / 2;
+  const x1 = w - colW / 2;
+  svg.appendChild(
+    svgEl("line", {
+      x1: x0,
+      y1: railY,
+      x2: x1,
+      y2: railY,
+      stroke: LINE,
+      "stroke-width": 2,
+    })
+  );
+
+  for (let i = 0; i < nSeq; i++) {
+    const x = colW * (i + 0.5);
+    // Drop from rail to just above arrow tip
+    svg.appendChild(
+      svgEl("line", {
+        x1: x,
+        y1: railY,
+        x2: x,
+        y2: tipY - arrowH + 2,
+        stroke: LINE,
+        "stroke-width": 2,
+      })
+    );
+    // Arrowhead overlapping the shaft end
+    svg.appendChild(
+      svgEl("polygon", {
+        points: `${x - arrowHalf},${tipY - arrowH} ${x + arrowHalf},${tipY - arrowH} ${x},${tipY}`,
+        fill: LINE,
+      })
+    );
+  }
+
+  return svg;
+}
+
 /**
  * CONSORT-style cluster flow: assessed → excluded side branch → randomised →
  * five implementation-sequence strips (month cells).
@@ -137,9 +255,11 @@ function sequenceColumn(seq: ImplementationSequence, totalMonths: number): HTMLE
 export function createSequencesChart(data: TrialDesignData = trialDesign): HTMLElement {
   const sequences = implementationSequences(data);
   const totalMonths = sequences[0]?.totalMonths ?? data.parameters.totalMonths;
+  const nSeq = sequences.length;
 
   const chart = document.createElement("div");
   chart.className = "consort-flow";
+  chart.style.setProperty("--consort-seqs", String(nSeq));
   chart.setAttribute(
     "aria-label",
     "Cluster flow: hospitals are assessed for eligibility, then randomised to one of five implementation sequences"
@@ -152,18 +272,16 @@ export function createSequencesChart(data: TrialDesignData = trialDesign): HTMLE
   const mid = document.createElement("div");
   mid.className = "consort-flow__mid";
 
-  const stem = document.createElement("div");
-  stem.className = "consort-flow__stem";
-  stem.setAttribute("aria-hidden", "true");
-  const stemLine = document.createElement("div");
-  stemLine.className = "consort-flow__stem-line";
-  const stemBranch = document.createElement("div");
-  stemBranch.className = "consort-flow__stem-branch";
-  stem.append(stemLine, stemBranch);
-  mid.appendChild(stem);
+  const connectors = document.createElement("div");
+  connectors.className = "consort-flow__mid-connectors";
+  connectors.setAttribute("aria-hidden", "true");
+  connectors.appendChild(createMidConnectors());
+  mid.appendChild(connectors);
 
-  const exclusion = exclusionBox();
-  mid.appendChild(exclusion);
+  const exclWrap = document.createElement("div");
+  exclWrap.className = "consort-flow__excl-wrap";
+  exclWrap.appendChild(exclusionBox());
+  mid.appendChild(exclWrap);
   chart.appendChild(mid);
 
   const randomised = flowBox("Clusters randomised");
@@ -173,10 +291,11 @@ export function createSequencesChart(data: TrialDesignData = trialDesign): HTMLE
   const sequencesBlock = document.createElement("div");
   sequencesBlock.className = "consort-flow__sequences";
 
-  const bus = document.createElement("div");
-  bus.className = "consort-flow__bus";
-  bus.setAttribute("aria-hidden", "true");
-  sequencesBlock.appendChild(bus);
+  const fan = document.createElement("div");
+  fan.className = "consort-flow__fan";
+  fan.setAttribute("aria-hidden", "true");
+  fan.appendChild(createFanSvg(nSeq));
+  sequencesBlock.appendChild(fan);
 
   const cols = document.createElement("div");
   cols.className = "consort-sequences";

--- a/presentations/atls-sweden-30-years/src/sequences.ts
+++ b/presentations/atls-sweden-30-years/src/sequences.ts
@@ -15,6 +15,15 @@ export interface ImplementationSequence {
 
 const PHASE_ORDER = ["Standard care", "Transition", "Intervention"] as const;
 
+/** Lighter fills for month cells — match the CONSORT shell figure. */
+const STRIP_COLORS: Record<string, string> = {
+  "Standard care": "#FCCE94",
+  Transition: "#92D9E6",
+  Intervention: "#BFA6D6",
+};
+
+const BOX_FILL = "#FCCE94";
+
 export function implementationSequences(
   data: TrialDesignData = trialDesign,
   batch = 1
@@ -45,113 +54,159 @@ export function implementationSequences(
   });
 }
 
-function monthsLabel(n: number): string {
-  return n === 1 ? "1 month" : `${n} months`;
-}
-
 function phaseClass(phase: string): string {
   return phase.toLowerCase().replace(/\s+/g, "-");
 }
 
-function barLabel(phase: SequencePhase): string {
-  if (phase.phase === "Transition") return "ATLS®";
-  return monthsLabel(phase.months);
+function monthPhases(seq: ImplementationSequence): string[] {
+  const months: string[] = [];
+  for (const phase of seq.phases) {
+    for (let i = 0; i < phase.months; i++) months.push(phase.phase);
+  }
+  return months;
 }
 
+function flowBox(text: string, kind: "primary" | "side" = "primary"): HTMLElement {
+  const box = document.createElement("div");
+  box.className = `consort-box consort-box--${kind}`;
+  if (kind === "primary") box.style.background = BOX_FILL;
+  box.textContent = text;
+  return box;
+}
+
+function exclusionBox(): HTMLElement {
+  const box = document.createElement("aside");
+  box.className = "consort-box consort-box--side";
+  const title = document.createElement("p");
+  title.className = "consort-box__title";
+  title.textContent = "Excluded before randomisation:";
+  const list = document.createElement("ul");
+  list.className = "consort-box__list";
+  for (const item of [
+    "Not meeting inclusion criteria",
+    "Declined to participate",
+    "Other reasons",
+  ]) {
+    const li = document.createElement("li");
+    li.textContent = item;
+    list.appendChild(li);
+  }
+  box.append(title, list);
+  return box;
+}
+
+function sequenceColumn(seq: ImplementationSequence, totalMonths: number): HTMLElement {
+  const col = document.createElement("div");
+  col.className = "consort-sequence";
+  col.dataset.sequence = String(seq.sequence);
+
+  const drop = document.createElement("div");
+  drop.className = "consort-sequence__drop";
+  drop.setAttribute("aria-hidden", "true");
+  col.appendChild(drop);
+
+  const title = document.createElement("p");
+  title.className = "consort-sequence__title";
+  title.textContent = `Sequence ${seq.sequence}`;
+  col.appendChild(title);
+
+  const strip = document.createElement("div");
+  strip.className = "consort-strip";
+  strip.style.gridTemplateColumns = `repeat(${totalMonths}, minmax(0, 1fr))`;
+  strip.setAttribute(
+    "aria-label",
+    `Sequence ${seq.sequence}: ${seq.phases[0].months} months standard care, training, ${seq.phases[2].months} months intervention`
+  );
+
+  for (const phase of monthPhases(seq)) {
+    const cell = document.createElement("span");
+    cell.className = `consort-cell consort-cell--${phaseClass(phase)}`;
+    cell.style.background = STRIP_COLORS[phase] ?? "#ccc";
+    cell.title = phase;
+    strip.appendChild(cell);
+  }
+
+  col.appendChild(strip);
+  return col;
+}
+
+/**
+ * CONSORT-style cluster flow: assessed → excluded side branch → randomised →
+ * five implementation-sequence strips (month cells).
+ */
 export function createSequencesChart(data: TrialDesignData = trialDesign): HTMLElement {
   const sequences = implementationSequences(data);
   const totalMonths = sequences[0]?.totalMonths ?? data.parameters.totalMonths;
+
   const chart = document.createElement("div");
-  chart.className = "sequences-chart";
+  chart.className = "consort-flow";
   chart.setAttribute(
     "aria-label",
-    `Five implementation sequences. Sequence 1 has ${sequences[0]?.phases[0]?.months} months of standard care, training, then ${sequences[0]?.phases[2]?.months} months of intervention. Each later sequence adds one month of standard care and one fewer month of intervention.`
+    "Cluster flow: hospitals are assessed for eligibility, then randomised to one of five implementation sequences"
   );
 
-  const axis = document.createElement("div");
-  axis.className = "sequences-axis";
-  axis.setAttribute("aria-hidden", "true");
-  const axisSpacer = document.createElement("span");
-  axisSpacer.className = "sequences-axis__label";
-  axis.appendChild(axisSpacer);
+  const assessed = flowBox("Clusters assessed for eligibility");
+  assessed.classList.add("consort-flow__assessed");
+  chart.appendChild(assessed);
 
-  const ticks = document.createElement("div");
-  ticks.className = "sequences-axis__ticks";
-  const tickStep = 2;
-  for (let month = 0; month <= totalMonths; month += tickStep) {
-    const tick = document.createElement("span");
-    tick.className = "sequences-axis__tick";
-    tick.style.left = `${(month / totalMonths) * 100}%`;
-    tick.textContent = String(month);
-    ticks.appendChild(tick);
-  }
-  if (totalMonths % tickStep !== 0) {
-    const endTick = document.createElement("span");
-    endTick.className = "sequences-axis__tick sequences-axis__tick--end";
-    endTick.style.left = "100%";
-    endTick.textContent = String(totalMonths);
-    ticks.appendChild(endTick);
-  }
-  axis.appendChild(ticks);
-  chart.appendChild(axis);
+  const mid = document.createElement("div");
+  mid.className = "consort-flow__mid";
 
-  const rows = document.createElement("div");
-  rows.className = "sequences-rows";
+  const stem = document.createElement("div");
+  stem.className = "consort-flow__stem";
+  stem.setAttribute("aria-hidden", "true");
+  const stemLine = document.createElement("div");
+  stemLine.className = "consort-flow__stem-line";
+  const stemBranch = document.createElement("div");
+  stemBranch.className = "consort-flow__stem-branch";
+  stem.append(stemLine, stemBranch);
+  mid.appendChild(stem);
 
+  const exclusion = exclusionBox();
+  mid.appendChild(exclusion);
+  chart.appendChild(mid);
+
+  const randomised = flowBox("Clusters randomised");
+  randomised.classList.add("consort-flow__randomised");
+  chart.appendChild(randomised);
+
+  const sequencesBlock = document.createElement("div");
+  sequencesBlock.className = "consort-flow__sequences";
+
+  const bus = document.createElement("div");
+  bus.className = "consort-flow__bus";
+  bus.setAttribute("aria-hidden", "true");
+  sequencesBlock.appendChild(bus);
+
+  const cols = document.createElement("div");
+  cols.className = "consort-sequences";
   for (const seq of sequences) {
-    const row = document.createElement("div");
-    row.className = "sequence-row";
-    row.dataset.sequence = String(seq.sequence);
-
-    const label = document.createElement("p");
-    label.className = "sequence-row__label";
-    label.textContent = `Sequence ${seq.sequence}`;
-    row.appendChild(label);
-
-    const track = document.createElement("div");
-    track.className = "sequence-row__track";
-    track.style.gridTemplateColumns = `repeat(${totalMonths}, minmax(0, 1fr))`;
-
-    for (const phase of seq.phases) {
-      const bar = document.createElement("div");
-      bar.className = `sequence-bar sequence-bar--${phaseClass(phase.phase)}`;
-      bar.style.gridColumn = `${phase.start + 1} / ${phase.end + 1}`;
-      bar.style.background = data.colors[phase.phase] ?? "#999999";
-      bar.title = `${phase.phase}: ${monthsLabel(phase.months)}`;
-      const text = document.createElement("span");
-      text.className = "sequence-bar__text";
-      text.textContent = barLabel(phase);
-      bar.appendChild(text);
-      track.appendChild(bar);
-    }
-
-    row.appendChild(track);
-    rows.appendChild(row);
+    cols.appendChild(sequenceColumn(seq, totalMonths));
   }
-
-  chart.appendChild(rows);
-
-  const axisTitle = document.createElement("p");
-  axisTitle.className = "sequences-axis-title";
-  axisTitle.textContent = "Study month";
-  chart.appendChild(axisTitle);
+  sequencesBlock.appendChild(cols);
+  chart.appendChild(sequencesBlock);
 
   return chart;
 }
 
-export function createSequencesLegend(data: TrialDesignData = trialDesign): HTMLElement {
+export function createSequencesLegend(): HTMLElement {
   const el = document.createElement("div");
   el.className = "wedge-legend sequences-legend";
   el.setAttribute("aria-hidden", "true");
-  for (const phase of data.legend) {
+  const labels: Array<[string, string]> = [
+    ["Standard care", STRIP_COLORS["Standard care"]],
+    ["Training", STRIP_COLORS.Transition],
+    ["Intervention", STRIP_COLORS.Intervention],
+  ];
+  for (const [text, color] of labels) {
     const item = document.createElement("span");
     item.className = "wedge-legend__item";
     const swatch = document.createElement("span");
     swatch.className = "wedge-legend__swatch";
-    swatch.style.background = data.colors[phase] ?? "#999999";
+    swatch.style.background = color;
     const label = document.createElement("span");
     label.className = "wedge-legend__label";
-    label.textContent = phase === "Transition" ? "Training (1 month)" : phase;
+    label.textContent = text;
     item.append(swatch, label);
     el.appendChild(item);
   }

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -36,6 +36,7 @@ export interface Slide {
     | "visual"
     | "design"
     | "design-animation"
+    | "sequences"
     | "forest"
     | "implications"
     | "closing"
@@ -340,6 +341,12 @@ export const slides: Slide[] = [
     layout: "design-animation",
     title: "How the trial unfolds",
     designVariant: "main",
+  },
+  {
+    id: "sequences",
+    layout: "sequences",
+    title: "Randomisation to sequences",
+    body: "Within each batch, the five hospitals are randomised to one of five implementation sequences. Sequence 1 is four months of standard care, then training, then eight months of intervention. Sequence 2 is five months of standard care, then training, then seven months of intervention — and so on.",
   },
   {
     id: "intervention",

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -346,7 +346,6 @@ export const slides: Slide[] = [
     id: "sequences",
     layout: "sequences",
     title: "Randomisation to sequences",
-    body: "Within each batch, the five hospitals are randomised to one of five implementation sequences. Sequence 1 is four months of standard care, then training, then eight months of intervention. Sequence 2 is five months of standard care, then training, then seven months of intervention — and so on.",
   },
   {
     id: "intervention",

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1099,8 +1099,9 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0;
-  padding: 0.35rem 0.5rem 0.25rem;
+  padding: 0.15rem 0.5rem 0.1rem;
 }
 
 .consort-box {
@@ -1149,7 +1150,7 @@ body {
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   width: min(92%, 52rem);
-  min-height: 5.5rem;
+  min-height: 4.75rem;
 }
 
 .consort-flow__stem {
@@ -1157,7 +1158,7 @@ body {
   position: relative;
   width: 1.5rem;
   height: 100%;
-  min-height: 5.5rem;
+  min-height: 4.75rem;
   justify-self: center;
 }
 
@@ -1175,7 +1176,7 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: calc(0.75rem + min(17rem, 34vw) * 0.15);
+  width: 1.1rem;
   height: 1.5px;
   background: var(--consort-line);
 }
@@ -1196,7 +1197,7 @@ body {
 .consort-flow__mid .consort-box--side {
   grid-column: 3;
   justify-self: start;
-  margin-left: 0.15rem;
+  margin-left: 0;
 }
 
 .consort-flow__sequences {
@@ -1204,15 +1205,15 @@ body {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  margin-top: 0.15rem;
-  flex: 1;
-  min-height: 0;
+  margin-top: 0;
+  flex: 0 0 auto;
 }
 
 .consort-flow__bus {
   position: relative;
-  height: 1.35rem;
-  margin: 0 6%;
+  height: 1.15rem;
+  /* Align ends with centres of first/last sequence columns */
+  margin: 0 calc(10% - 0.35rem);
 }
 
 .consort-flow__bus::before {
@@ -1221,7 +1222,7 @@ body {
   left: 50%;
   top: 0;
   width: 1.5px;
-  height: 0.55rem;
+  height: 0.45rem;
   background: var(--consort-line);
   transform: translateX(-50%);
 }
@@ -1231,7 +1232,7 @@ body {
   position: absolute;
   left: 0;
   right: 0;
-  top: 0.55rem;
+  top: 0.45rem;
   height: 1.5px;
   background: var(--consort-line);
 }
@@ -1239,8 +1240,7 @@ body {
 .consort-sequences {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.55rem 0.7rem;
-  flex: 1;
+  gap: 0.45rem 0.7rem;
   align-content: start;
 }
 
@@ -1248,13 +1248,13 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.3rem;
   min-width: 0;
 }
 
 .consort-sequence__drop {
   width: 1.5px;
-  height: 0.85rem;
+  height: 0.7rem;
   background: var(--consort-line);
   position: relative;
 }
@@ -1285,13 +1285,13 @@ body {
   display: grid;
   width: 100%;
   gap: 1.5px;
-  min-height: 1.35rem;
+  min-height: 1.55rem;
 }
 
 .consort-cell {
   display: block;
   min-width: 0;
-  min-height: 1.35rem;
+  min-height: 1.55rem;
   border: 1px solid color-mix(in srgb, var(--ink) 18%, transparent);
   border-radius: 1px;
 }

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1055,6 +1055,152 @@ body {
   transform-box: fill-box;
 }
 
+/* ── Implementation sequences ───────────────────────────────────── */
+
+.slide-inner--sequences {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  max-width: 1280px;
+}
+
+.slide-inner--sequences > h2 {
+  flex-shrink: 0;
+}
+
+.sequences-lead {
+  margin: 0 0 0.9rem;
+  max-width: 68ch;
+  color: var(--text);
+  font-size: clamp(0.92rem, 1.55vw, 1.08rem);
+  line-height: 1.45;
+}
+
+.sequences-panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.sequences-chart {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.85rem 1rem 0.7rem;
+}
+
+.sequences-axis,
+.sequence-row {
+  display: grid;
+  grid-template-columns: 7.2rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.sequences-axis__label {
+  min-height: 1rem;
+}
+
+.sequences-axis__ticks {
+  position: relative;
+  height: 1.1rem;
+}
+
+.sequences-axis__tick {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.sequences-axis__tick:first-child {
+  transform: translateX(0);
+}
+
+.sequences-axis__tick:last-child {
+  transform: translateX(-100%);
+}
+
+.sequences-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  flex: 1;
+  justify-content: space-evenly;
+}
+
+.sequence-row__label {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--ink);
+  line-height: 1.2;
+}
+
+.sequence-row__track {
+  display: grid;
+  gap: 0.2rem;
+  min-height: 2.6rem;
+}
+
+.sequence-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  border-radius: 3px;
+  color: var(--text-inverse);
+  padding: 0.2rem 0.35rem;
+}
+
+.sequence-bar__text {
+  font-size: clamp(0.62rem, 1.1vw, 0.82rem);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sequence-bar--transition .sequence-bar__text {
+  font-size: clamp(0.55rem, 0.95vw, 0.72rem);
+  writing-mode: horizontal-tb;
+}
+
+.sequences-axis-title {
+  margin: 0.15rem 0 0;
+  padding-left: calc(7.2rem + 0.75rem);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .sequences-axis,
+  .sequence-row {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+
+  .sequences-axis-title {
+    padding-left: 0;
+  }
+
+  .sequence-row__track {
+    min-height: 2.2rem;
+  }
+}
+
 .forest-container {
   margin-top: 0.6rem;
   background: var(--surface-muted);

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1055,7 +1055,7 @@ body {
   transform-box: fill-box;
 }
 
-/* ── Implementation sequences ───────────────────────────────────── */
+/* ── Implementation sequences (CONSORT-style flow) ──────────────── */
 
 .slide-inner--sequences {
   display: flex;
@@ -1067,14 +1067,7 @@ body {
 
 .slide-inner--sequences > h2 {
   flex-shrink: 0;
-}
-
-.sequences-lead {
-  margin: 0 0 0.9rem;
-  max-width: 68ch;
-  color: var(--text);
-  font-size: clamp(0.92rem, 1.55vw, 1.08rem);
-  line-height: 1.45;
+  margin-bottom: 0.65rem;
 }
 
 .sequences-panel {
@@ -1082,122 +1075,267 @@ body {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.7rem;
+  gap: 0.75rem;
 }
 
-.sequences-chart {
+.sequences-mount {
   flex: 1;
   min-height: 0;
   display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.85rem 1rem 0.7rem;
 }
 
-.sequences-axis,
-.sequence-row {
-  display: grid;
-  grid-template-columns: 7.2rem minmax(0, 1fr);
-  gap: 0.75rem;
-  align-items: center;
+.sequences-legend-mount {
+  flex-shrink: 0;
+  display: flex;
+  justify-content: center;
 }
 
-.sequences-axis__label {
-  min-height: 1rem;
-}
-
-.sequences-axis__ticks {
-  position: relative;
-  height: 1.1rem;
-}
-
-.sequences-axis__tick {
-  position: absolute;
-  top: 0;
-  transform: translateX(-50%);
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-}
-
-.sequences-axis__tick:first-child {
-  transform: translateX(0);
-}
-
-.sequences-axis__tick:last-child {
-  transform: translateX(-100%);
-}
-
-.sequences-rows {
+.consort-flow {
+  --consort-line: #6b7a80;
+  --consort-box-border: #8a969b;
+  flex: 1;
+  width: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  flex: 1;
-  justify-content: space-evenly;
+  align-items: center;
+  gap: 0;
+  padding: 0.35rem 0.5rem 0.25rem;
 }
 
-.sequence-row__label {
-  margin: 0;
-  font-size: 0.88rem;
+.consort-box {
+  border: 1px solid var(--consort-box-border);
+  border-radius: 2px;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: clamp(0.78rem, 1.35vw, 0.95rem);
+  line-height: 1.3;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.consort-box--primary {
+  width: min(42%, 28rem);
+  padding: 0.55rem 1rem;
   font-weight: 500;
+}
+
+.consort-box--side {
+  background: var(--surface);
+  text-align: left;
+  padding: 0.45rem 0.7rem;
+  width: min(100%, 17rem);
+}
+
+.consort-box__title {
+  margin: 0 0 0.2rem;
+  font-weight: 500;
+  font-size: inherit;
+}
+
+.consort-box__list {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.92em;
+  color: var(--text);
+}
+
+.consort-box__list li {
+  margin: 0.05rem 0;
+}
+
+.consort-flow__mid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  width: min(92%, 52rem);
+  min-height: 5.5rem;
+}
+
+.consort-flow__stem {
+  grid-column: 2;
+  position: relative;
+  width: 1.5rem;
+  height: 100%;
+  min-height: 5.5rem;
+  justify-self: center;
+}
+
+.consort-flow__stem-line {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1.5px;
+  background: var(--consort-line);
+  transform: translateX(-50%);
+}
+
+.consort-flow__stem-branch {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: calc(0.75rem + min(17rem, 34vw) * 0.15);
+  height: 1.5px;
+  background: var(--consort-line);
+}
+
+.consort-flow__stem-branch::after {
+  content: "";
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 7px solid var(--consort-line);
+  transform: translateY(-50%);
+}
+
+.consort-flow__mid .consort-box--side {
+  grid-column: 3;
+  justify-self: start;
+  margin-left: 0.15rem;
+}
+
+.consort-flow__sequences {
+  width: min(96%, 68rem);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  margin-top: 0.15rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.consort-flow__bus {
+  position: relative;
+  height: 1.35rem;
+  margin: 0 6%;
+}
+
+.consort-flow__bus::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 1.5px;
+  height: 0.55rem;
+  background: var(--consort-line);
+  transform: translateX(-50%);
+}
+
+.consort-flow__bus::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0.55rem;
+  height: 1.5px;
+  background: var(--consort-line);
+}
+
+.consort-sequences {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.55rem 0.7rem;
+  flex: 1;
+  align-content: start;
+}
+
+.consort-sequence {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.consort-sequence__drop {
+  width: 1.5px;
+  height: 0.85rem;
+  background: var(--consort-line);
+  position: relative;
+}
+
+.consort-sequence__drop::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -1px;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid var(--consort-line);
+  transform: translateX(-50%);
+}
+
+.consort-sequence__title {
+  margin: 0;
+  font-size: clamp(0.72rem, 1.2vw, 0.88rem);
+  font-weight: 600;
   color: var(--ink);
   line-height: 1.2;
-}
-
-.sequence-row__track {
-  display: grid;
-  gap: 0.2rem;
-  min-height: 2.6rem;
-}
-
-.sequence-bar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 0;
-  border-radius: 3px;
-  color: var(--text-inverse);
-  padding: 0.2rem 0.35rem;
-}
-
-.sequence-bar__text {
-  font-size: clamp(0.62rem, 1.1vw, 0.82rem);
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.sequence-bar--transition .sequence-bar__text {
-  font-size: clamp(0.55rem, 0.95vw, 0.72rem);
-  writing-mode: horizontal-tb;
-}
-
-.sequences-axis-title {
-  margin: 0.15rem 0 0;
-  padding-left: calc(7.2rem + 0.75rem);
-  font-size: 0.72rem;
-  color: var(--text-muted);
   text-align: center;
 }
 
-@media (max-width: 720px) {
-  .sequences-axis,
-  .sequence-row {
+.consort-strip {
+  display: grid;
+  width: 100%;
+  gap: 1.5px;
+  min-height: 1.35rem;
+}
+
+.consort-cell {
+  display: block;
+  min-width: 0;
+  min-height: 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--ink) 18%, transparent);
+  border-radius: 1px;
+}
+
+@media (max-width: 900px) {
+  .consort-box--primary {
+    width: min(78%, 28rem);
+  }
+
+  .consort-flow__mid {
     grid-template-columns: 1fr;
-    gap: 0.3rem;
+    grid-template-rows: auto auto;
+    min-height: 0;
+    gap: 0.35rem;
+    width: min(92%, 28rem);
   }
 
-  .sequences-axis-title {
-    padding-left: 0;
+  .consort-flow__stem {
+    grid-column: 1;
+    min-height: 2rem;
+    height: 2rem;
   }
 
-  .sequence-row__track {
-    min-height: 2.2rem;
+  .consort-flow__stem-branch {
+    display: none;
+  }
+
+  .consort-flow__mid .consort-box--side {
+    grid-column: 1;
+    justify-self: center;
+    width: 100%;
+  }
+
+  .consort-sequences {
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+  }
+
+  .consort-flow__bus {
+    display: none;
+  }
+
+  .consort-sequence__drop {
+    display: none;
   }
 }
 

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1093,6 +1093,7 @@ body {
 .consort-flow {
   --consort-line: #6b7a80;
   --consort-box-border: #8a969b;
+  --consort-seqs: 5;
   flex: 1;
   width: 100%;
   min-height: 0;
@@ -1101,7 +1102,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 0;
-  padding: 0.15rem 0.5rem 0.1rem;
+  padding: 0.25rem 0.5rem 0.15rem;
 }
 
 .consort-box {
@@ -1146,58 +1147,35 @@ body {
 }
 
 .consort-flow__mid {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  width: min(92%, 52rem);
-  min-height: 4.75rem;
-}
-
-.consort-flow__stem {
-  grid-column: 2;
   position: relative;
-  width: 1.5rem;
-  height: 100%;
-  min-height: 4.75rem;
-  justify-self: center;
+  width: min(52rem, 92%);
+  flex: 0 0 auto;
+  min-height: 11.5rem;
 }
 
-.consort-flow__stem-line {
+.consort-flow__mid-connectors {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.consort-mid-svg {
   position: absolute;
   left: 50%;
   top: 0;
-  bottom: 0;
-  width: 1.5px;
-  background: var(--consort-line);
-  transform: translateX(-50%);
+  height: 100%;
+  /* viewBox stem is at x=20; shift so that sits on the centre axis */
+  width: 12.5rem;
+  transform: translateX(-20px);
+  display: block;
+  overflow: visible;
 }
 
-.consort-flow__stem-branch {
+.consort-flow__excl-wrap {
   position: absolute;
+  left: calc(50% + 3.65rem);
   top: 50%;
-  left: 50%;
-  width: 1.1rem;
-  height: 1.5px;
-  background: var(--consort-line);
-}
-
-.consort-flow__stem-branch::after {
-  content: "";
-  position: absolute;
-  right: -1px;
-  top: 50%;
-  width: 0;
-  height: 0;
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  border-left: 7px solid var(--consort-line);
   transform: translateY(-50%);
-}
-
-.consort-flow__mid .consort-box--side {
-  grid-column: 3;
-  justify-self: start;
-  margin-left: 0;
 }
 
 .consort-flow__sequences {
@@ -1209,67 +1187,32 @@ body {
   flex: 0 0 auto;
 }
 
-.consort-flow__bus {
-  position: relative;
-  height: 1.15rem;
-  /* Align ends with centres of first/last sequence columns */
-  margin: 0 calc(10% - 0.35rem);
+.consort-flow__fan {
+  width: 100%;
+  height: 3.35rem;
 }
 
-.consort-flow__bus::before {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 0;
-  width: 1.5px;
-  height: 0.45rem;
-  background: var(--consort-line);
-  transform: translateX(-50%);
-}
-
-.consort-flow__bus::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0.45rem;
-  height: 1.5px;
-  background: var(--consort-line);
+.consort-fan-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  overflow: visible;
 }
 
 .consort-sequences {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.45rem 0.7rem;
+  grid-template-columns: repeat(var(--consort-seqs), minmax(0, 1fr));
+  gap: 0.55rem 0.7rem;
   align-content: start;
+  margin-top: 0.35rem;
 }
 
 .consort-sequence {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.35rem;
   min-width: 0;
-}
-
-.consort-sequence__drop {
-  width: 1.5px;
-  height: 0.7rem;
-  background: var(--consort-line);
-  position: relative;
-}
-
-.consort-sequence__drop::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  bottom: -1px;
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 7px solid var(--consort-line);
-  transform: translateX(-50%);
 }
 
 .consort-sequence__title {
@@ -1302,27 +1245,20 @@ body {
   }
 
   .consort-flow__mid {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto;
-    min-height: 0;
-    gap: 0.35rem;
     width: min(92%, 28rem);
+    min-height: 11rem;
   }
 
-  .consort-flow__stem {
-    grid-column: 1;
-    min-height: 2rem;
-    height: 2rem;
+  .consort-mid-svg {
+    width: 3rem;
+    transform: translateX(-20px);
   }
 
-  .consort-flow__stem-branch {
-    display: none;
-  }
-
-  .consort-flow__mid .consort-box--side {
-    grid-column: 1;
-    justify-self: center;
-    width: 100%;
+  .consort-flow__excl-wrap {
+    left: 50%;
+    top: auto;
+    bottom: 0;
+    transform: translateX(-50%);
   }
 
   .consort-sequences {
@@ -1330,11 +1266,7 @@ body {
     gap: 0.85rem;
   }
 
-  .consort-flow__bus {
-    display: none;
-  }
-
-  .consort-sequence__drop {
+  .consort-flow__fan {
     display: none;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reworks the sequences slide in the ATLS Sweden 30-year deck into a CONSORT-style cluster flowchart.

Flow: clusters assessed for eligibility → excluded before randomisation (side branch) → clusters randomised → five implementation sequences with month-cell strips (4+8 through 8+4 around the training month). Explanatory body text removed.

Connectors are SVG so stems, rails, and arrowheads join continuously, with clearer vertical space between the eligibility and randomisation boxes.

[CONSORT-style sequences randomisation slide](https://cursor.com/agents/bc-66bd1dc3-4500-46c5-b57f-2e05dbf53444/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsequences_consort_spacing_fixed.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66bd1dc3-4500-46c5-b57f-2e05dbf53444?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66bd1dc3-4500-46c5-b57f-2e05dbf53444&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

