### PR TITLE
Add thumbnail slide overview for ATLS Sweden presentation

### DIFF
--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -9,7 +9,7 @@ pnpm install
 pnpm dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173). Use arrow keys, space, or swipe to navigate. Press **F** for fullscreen.
+Open [http://localhost:5173](http://localhost:5173). Use arrow keys, space, or swipe to navigate. Press **O** (or the grid / counter controls) for a thumbnail overview to jump to any slide. Press **F** for fullscreen.
 
 ## Build for website
 
@@ -30,6 +30,7 @@ Image assets in `public/` are copied to `dist/` during build:
 
 - **Motion** animations — staggered entrance, forest plot and stepped-wedge reveal
 - **Deep linking** — each slide has a URL hash (e.g. `#design`)
+- **Slide overview** — thumbnail filmstrip to jump to any slide (`O`, grid button, or counter)
 - **Responsive** — works on projectors, laptops, and tablets
 - **Accessible** — keyboard navigation, ARIA labels, reduced-motion support
 - **Brand-aligned** — colours and typography match advancetrauma.info

--- a/presentations/atls-sweden-30-years/index.html
+++ b/presentations/atls-sweden-30-years/index.html
@@ -24,13 +24,58 @@
             <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
-        <span id="slide-counter" aria-live="polite"></span>
+        <button
+          id="overview-toggle"
+          type="button"
+          aria-label="Open slide overview"
+          title="Overview (O)"
+          aria-controls="overview"
+          aria-expanded="false"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="currentColor" aria-hidden="true">
+            <rect x="1" y="1" width="6" height="6" rx="1" />
+            <rect x="11" y="1" width="6" height="6" rx="1" />
+            <rect x="1" y="11" width="6" height="6" rx="1" />
+            <rect x="11" y="11" width="6" height="6" rx="1" />
+          </svg>
+        </button>
+        <button
+          id="slide-counter"
+          type="button"
+          aria-live="polite"
+          aria-label="Open slide overview"
+          title="Jump to slide (O)"
+        ></button>
         <button id="next" aria-label="Next slide" title="Next (→)">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path d="M7.5 5L12.5 10L7.5 15" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
       </nav>
+      <div id="overview" hidden aria-hidden="true">
+        <button
+          type="button"
+          id="overview-backdrop"
+          aria-label="Close slide overview"
+          tabindex="-1"
+        ></button>
+        <div
+          id="overview-panel"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="overview-heading"
+        >
+          <div class="overview-header">
+            <h2 id="overview-heading">Jump to slide</h2>
+            <button type="button" id="overview-close" aria-label="Close overview" title="Close (Esc)">
+              <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+                <path d="M4.5 4.5L13.5 13.5M13.5 4.5L4.5 13.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </button>
+          </div>
+          <div id="overview-filmstrip" role="list"></div>
+        </div>
+      </div>
       <div id="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100">
         <div id="progress-bar"></div>
       </div>

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -8,6 +8,7 @@ import "./style.css";
 
 let currentIndex = 0;
 let isAnimating = false;
+let overviewOpen = false;
 const forestControllers = new WeakMap<HTMLElement, ForestPlotController>();
 let designReveal: DesignRevealControls | null = null;
 
@@ -16,6 +17,12 @@ const counterEl = document.getElementById("slide-counter")!;
 const progressBar = document.getElementById("progress-bar")!;
 const prevBtn = document.getElementById("prev")!;
 const nextBtn = document.getElementById("next")!;
+const overviewEl = document.getElementById("overview")!;
+const overviewFilmstrip = document.getElementById("overview-filmstrip")!;
+const overviewToggle = document.getElementById("overview-toggle")!;
+const overviewClose = document.getElementById("overview-close")!;
+const overviewBackdrop = document.getElementById("overview-backdrop")!;
+const overviewPanel = document.getElementById("overview-panel");
 
 function evidenceCardClass(tag?: string): string {
   switch (tag) {
@@ -501,11 +508,133 @@ function mountSlides(): void {
   });
 }
 
+function slideThumbLabel(slide: Slide): string {
+  return slide.title ?? slide.subtitle ?? slide.id;
+}
+
+function thumbPreviewClass(slide: Slide): string {
+  if (
+    slide.layout === "title" ||
+    slide.layout === "closing" ||
+    slide.layout === "section" ||
+    slide.layout === "aim"
+  ) {
+    return `overview-thumb__preview--${slide.layout}`;
+  }
+  if (slide.image) return "overview-thumb__preview--image";
+  return "";
+}
+
+function thumbPreviewInner(slide: Slide): string {
+  const label = slideThumbLabel(slide);
+  const chips =
+    slide.layout === "stats" || slide.layout === "evidence" || slide.layout === "milestones"
+      ? `<div class="overview-thumb__chips" aria-hidden="true">
+          <span class="overview-thumb__chip"></span>
+          <span class="overview-thumb__chip overview-thumb__chip--accent"></span>
+          <span class="overview-thumb__chip overview-thumb__chip--purple"></span>
+        </div>`
+      : slide.layout === "design" || slide.layout === "design-animation" || slide.layout === "forest"
+        ? `<div class="overview-thumb__chips" aria-hidden="true">
+            <span class="overview-thumb__chip" style="max-width:100%"></span>
+          </div>`
+        : "";
+
+  return `${chips}<span class="overview-thumb__mini-title">${label}</span>`;
+}
+
+function mountOverview(): void {
+  overviewFilmstrip.innerHTML = "";
+  slides.forEach((slide, i) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "overview-thumb";
+    btn.dataset.index = String(i);
+    btn.setAttribute("role", "listitem");
+    btn.setAttribute("aria-label", `Go to slide ${i + 1}: ${slideThumbLabel(slide)}`);
+    if (i === currentIndex) btn.classList.add("is-current");
+
+    const previewClass = thumbPreviewClass(slide);
+    const imageStyle = slide.image ? ` style="background-image:url('${slide.image}')"` : "";
+
+    btn.innerHTML = `
+      <div class="overview-thumb__preview ${previewClass}"${imageStyle}>
+        <div class="overview-thumb__preview-inner">
+          ${thumbPreviewInner(slide)}
+        </div>
+      </div>
+      <div class="overview-thumb__meta">
+        <span class="overview-thumb__num">${i + 1}</span>
+        <span class="overview-thumb__label">${slideThumbLabel(slide)}</span>
+      </div>
+    `;
+
+    btn.addEventListener("click", () => {
+      const target = i;
+      closeOverview();
+      if (target !== currentIndex) goTo(target);
+    });
+
+    overviewFilmstrip.appendChild(btn);
+  });
+}
+
+function updateOverviewActive(): void {
+  const thumbs = overviewFilmstrip.querySelectorAll<HTMLButtonElement>(".overview-thumb");
+  thumbs.forEach((thumb, i) => {
+    thumb.classList.toggle("is-current", i === currentIndex);
+  });
+  const current = thumbs[currentIndex];
+  if (current && overviewOpen) {
+    current.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+  }
+}
+
+function openOverview(): void {
+  if (overviewOpen) return;
+  overviewOpen = true;
+  overviewEl.hidden = false;
+  overviewEl.setAttribute("aria-hidden", "false");
+  overviewToggle.setAttribute("aria-expanded", "true");
+  overviewToggle.setAttribute("aria-label", "Close slide overview");
+  document.body.classList.add("overview-open");
+  // Force reflow so the open transition runs.
+  void overviewEl.offsetWidth;
+  overviewEl.classList.add("is-open");
+  updateOverviewActive();
+  overviewClose.focus();
+}
+
+function closeOverview(): void {
+  if (!overviewOpen) return;
+  overviewOpen = false;
+  overviewEl.classList.remove("is-open");
+  overviewToggle.setAttribute("aria-expanded", "false");
+  overviewToggle.setAttribute("aria-label", "Open slide overview");
+  document.body.classList.remove("overview-open");
+
+  const finish = (): void => {
+    if (overviewOpen) return;
+    overviewEl.hidden = true;
+    overviewEl.setAttribute("aria-hidden", "true");
+  };
+
+  overviewPanel?.addEventListener("transitionend", finish, { once: true });
+  window.setTimeout(finish, 350);
+  overviewToggle.focus();
+}
+
+function toggleOverview(): void {
+  if (overviewOpen) closeOverview();
+  else openOverview();
+}
+
 function updateUI(): void {
   counterEl.textContent = `${currentIndex + 1} / ${slides.length}`;
   progressBar.style.width = `${((currentIndex + 1) / slides.length) * 100}%`;
   document.title = `${slides[currentIndex].title ?? "ADVANCE TRAUMA"} — ATLS Sweden 30 Years`;
   history.replaceState(null, "", `#${slides[currentIndex].id}`);
+  updateOverviewActive();
 }
 
 function animateSlideIn(slideEl: HTMLElement): void {
@@ -633,6 +762,51 @@ function initFromHash(): void {
 
 function setupKeyboard(): void {
   document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && overviewOpen) {
+      e.preventDefault();
+      closeOverview();
+      return;
+    }
+
+    if ((e.key === "o" || e.key === "O") && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      toggleOverview();
+      return;
+    }
+
+    if (overviewOpen) {
+      if (e.key === "ArrowRight" || e.key === "PageDown") {
+        e.preventDefault();
+        const nextThumb = Math.min(currentIndex + 1, slides.length - 1);
+        if (nextThumb !== currentIndex) goTo(nextThumb);
+        else updateOverviewActive();
+        return;
+      }
+      if (e.key === "ArrowLeft" || e.key === "PageUp") {
+        e.preventDefault();
+        const prevThumb = Math.max(currentIndex - 1, 0);
+        if (prevThumb !== currentIndex) goTo(prevThumb);
+        else updateOverviewActive();
+        return;
+      }
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        closeOverview();
+        return;
+      }
+      if (e.key === "Home") {
+        e.preventDefault();
+        goTo(0);
+        return;
+      }
+      if (e.key === "End") {
+        e.preventDefault();
+        goTo(slides.length - 1);
+        return;
+      }
+      return;
+    }
+
     const onStagedDesign = slides[currentIndex]?.layout === "design-animation";
 
     if (e.key === " " && onStagedDesign && designReveal) {
@@ -692,9 +866,14 @@ function setupTouch(): void {
 
 prevBtn.addEventListener("click", prev);
 nextBtn.addEventListener("click", next);
+overviewToggle.addEventListener("click", toggleOverview);
+counterEl.addEventListener("click", toggleOverview);
+overviewClose.addEventListener("click", closeOverview);
+overviewBackdrop.addEventListener("click", closeOverview);
 
 initFromHash();
 mountSlides();
+mountOverview();
 updateUI();
 
 const activeSlide = slidesEl.querySelector(".is-active") as HTMLElement;

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1624,6 +1624,285 @@ body {
   min-width: 4rem;
   text-align: center;
   user-select: none;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.35rem 0.55rem;
+  transition: background 0.15s, color 0.15s;
+}
+
+#slide-counter:hover,
+#overview-toggle:hover {
+  background: var(--surface-muted);
+  color: var(--brand-darker);
+}
+
+#overview-toggle {
+  color: var(--brand-deep);
+}
+
+/* ── Slide overview / thumbnail filmstrip ───────────────────────── */
+
+#overview {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  pointer-events: none;
+}
+
+#overview:not([hidden]) {
+  pointer-events: auto;
+}
+
+#overview-backdrop {
+  position: absolute;
+  inset: 0;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: color-mix(in srgb, var(--ink) 42%, transparent);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.25s var(--transition-smooth);
+}
+
+#overview.is-open #overview-backdrop {
+  opacity: 1;
+}
+
+#overview-panel {
+  position: relative;
+  z-index: 1;
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -12px 40px rgba(8, 40, 48, 0.14);
+  padding: 0.85rem 1rem 1.1rem;
+  transform: translateY(110%);
+  transition: transform 0.3s var(--transition-smooth);
+}
+
+#overview.is-open #overview-panel {
+  transform: translateY(0);
+}
+
+.overview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.overview-header h2 {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink);
+  border: none;
+}
+
+#overview-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+#overview-close:hover {
+  background: var(--surface-muted);
+  color: var(--ink);
+}
+
+#overview-filmstrip {
+  display: flex;
+  gap: 0.65rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.25rem 0.15rem 0.5rem;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.overview-thumb {
+  flex: 0 0 auto;
+  width: 148px;
+  border: 2px solid transparent;
+  border-radius: calc(var(--radius) + 2px);
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  scroll-snap-align: center;
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+}
+
+.overview-thumb:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--brand) 45%, transparent);
+}
+
+.overview-thumb:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.overview-thumb.is-current {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand) 35%, transparent);
+}
+
+.overview-thumb__preview {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+}
+
+.overview-thumb__preview--title,
+.overview-thumb__preview--closing {
+  background: linear-gradient(145deg, var(--brand) 0%, var(--brand-darker) 100%);
+  border-color: transparent;
+}
+
+.overview-thumb__preview--section {
+  background: linear-gradient(145deg, var(--accent) 0%, var(--accent-deep) 100%);
+  border-color: transparent;
+}
+
+.overview-thumb__preview--aim {
+  background: linear-gradient(160deg, var(--surface-muted) 0%, color-mix(in srgb, var(--brand) 18%, white) 100%);
+}
+
+.overview-thumb__preview--image {
+  background-size: cover;
+  background-position: center;
+}
+
+.overview-thumb__preview-inner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 0.4rem 0.45rem;
+  gap: 0.15rem;
+}
+
+.overview-thumb__preview--title .overview-thumb__preview-inner,
+.overview-thumb__preview--section .overview-thumb__preview-inner,
+.overview-thumb__preview--closing .overview-thumb__preview-inner {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: transparent;
+}
+
+.overview-thumb__preview--image .overview-thumb__preview-inner {
+  background: linear-gradient(to top, rgba(8, 40, 48, 0.72), transparent 65%);
+}
+
+.overview-thumb__preview:not(.overview-thumb__preview--title):not(.overview-thumb__preview--section):not(.overview-thumb__preview--closing):not(.overview-thumb__preview--image)
+  .overview-thumb__preview-inner {
+  background: linear-gradient(to top, rgba(255, 255, 255, 0.92), transparent 70%);
+}
+
+.overview-thumb__mini-title {
+  font-family: var(--font-display);
+  font-size: 0.58rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.overview-thumb__preview--title .overview-thumb__mini-title,
+.overview-thumb__preview--section .overview-thumb__mini-title,
+.overview-thumb__preview--closing .overview-thumb__mini-title,
+.overview-thumb__preview--image .overview-thumb__mini-title {
+  color: var(--text-inverse);
+}
+
+.overview-thumb__chips {
+  display: flex;
+  gap: 0.2rem;
+  margin-bottom: auto;
+}
+
+.overview-thumb__chip {
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--brand) 35%, white);
+  flex: 1;
+  max-width: 28px;
+}
+
+.overview-thumb__chip--accent {
+  background: color-mix(in srgb, var(--accent) 50%, white);
+}
+
+.overview-thumb__chip--purple {
+  background: color-mix(in srgb, var(--intervention) 45%, white);
+}
+
+.overview-thumb__meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+  padding: 0 0.1rem;
+}
+
+.overview-thumb__num {
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--brand-deep);
+  min-width: 1.2rem;
+}
+
+.overview-thumb__label {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.overview-thumb.is-current .overview-thumb__label {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+body.overview-open #controls {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
 }
 
 /* ── Progress bar ───────────────────────────────────────────────── */
@@ -1669,7 +1948,8 @@ body {
   }
 
   #controls,
-  #progress {
+  #progress,
+  #overview {
     display: none;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a thumbnail filmstrip so presenters can jump to any slide in the ATLS Sweden 30 Years deck.

## How to use
- Press **O**, click the **grid** button, or click the **slide counter** to open the overview
- Click a thumbnail to jump to that slide
- **Esc** / Enter / Space / backdrop / close button dismisses the bar
- Arrow keys still work while the overview is open (browse + preview)

## Implementation
- Bottom filmstrip with layout-aware miniature previews (brand colors for title/section/closing; image backgrounds where available)
- Current slide highlighted and scrolled into view
- README updated with the new shortcut

## Demo
[slide-overview-thumbnail-nav.mp4](https://cursor.com/agents/bc-0e7b8c8a-3235-4bbf-a9d2-3fde9870381c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslide-overview-thumbnail-nav.mp4)

[Overview filmstrip open](https://cursor.com/agents/bc-0e7b8c8a-3235-4bbf-a9d2-3fde9870381c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview-filmstrip-open.webp)
[After jumping to closing slide](https://cursor.com/agents/bc-0e7b8c8a-3235-4bbf-a9d2-3fde9870381c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview-closed-thank-you.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e7b8c8a-3235-4bbf-a9d2-3fde9870381c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e7b8c8a-3235-4bbf-a9d2-3fde9870381c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

