### PR TITLE
Add participating clusters map to ATLS Sweden 30-year presentation

### DIFF
--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -45,6 +45,7 @@ Image assets in `public/` are copied to `dist/` during build:
 | — | `atls-impact-sources` | Historical sources for manual Impact claims |
 | — | `atls-forest` | Updated systematic review forest plot |
 | 12–21 | Trial slides | Design, nested staircase, outcomes, status |
+| — | `participating-clusters` | Interactive map of currently participating hospitals |
 | 21–22 | `implications`, `closing` | Take-home messages |
 
 ## Source

--- a/presentations/atls-sweden-30-years/package.json
+++ b/presentations/atls-sweden-30-years/package.json
@@ -10,10 +10,12 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.22",
     "typescript": "^5.7.3",
     "vite": "^6.0.7"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "motion": "^12.4.7"
   }
 }

--- a/presentations/atls-sweden-30-years/pnpm-lock.yaml
+++ b/presentations/atls-sweden-30-years/pnpm-lock.yaml
@@ -8,10 +8,16 @@ importers:
 
   .:
     dependencies:
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
       motion:
         specifier: ^12.4.7
         version: 12.43.0
     devDependencies:
+      '@types/leaflet':
+        specifier: ^1.9.22
+        version: 1.9.22
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -311,6 +317,12 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/leaflet@1.9.22':
+    resolution: {integrity: sha512-h3lhECYEKDasG7LFHu+GiHqAvsgLuQvlJvVZzJDGONo3sEL+wUOqSFLnwkZlK0qVxnxbuGFW8iBlJNYs5wgndA==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -343,6 +355,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
 
   motion-dom@12.43.0:
     resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
@@ -601,6 +616,12 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/geojson@7946.0.16': {}
+
+  '@types/leaflet@1.9.22':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -642,6 +663,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  leaflet@1.9.4: {}
 
   motion-dom@12.43.0:
     dependencies:

--- a/presentations/atls-sweden-30-years/src/data/sites.ts
+++ b/presentations/atls-sweden-30-years/src/data/sites.ts
@@ -1,0 +1,232 @@
+/**
+ * Participating clusters — adapted from advancetrauma.info `src/data/sites.ts`.
+ * Keep in sync when sites are confirmed or batch windows change.
+ */
+
+export type SiteBatch = "1" | "2" | "3" | "4" | "5" | "6";
+
+export type BatchStatus = "upcoming" | "ongoing" | "completed" | "starting" | "screening";
+
+export type ParticipatingSite = {
+  name: string;
+  city: string;
+  state: string;
+  batch: SiteBatch;
+  website: string;
+  location: { lat: number; lng: number };
+  pi: string;
+  coordinators?: string;
+};
+
+export type SiteBatchInfo = {
+  id: SiteBatch;
+  title: string;
+  /** Inclusive start month as YYYY-MM */
+  start?: string;
+  /** Inclusive end month as YYYY-MM */
+  end?: string;
+  /** Explicit status; when set, overrides date-derived status */
+  status?: BatchStatus;
+  sites: ParticipatingSite[];
+};
+
+/** Batch marker/label colors — resolve from design tokens at call time. */
+export const batchColorTokens: Record<SiteBatch, string> = {
+  "1": "--brand",
+  "2": "--accent",
+  "3": "--brand-deep",
+  "4": "--accent-hover",
+  "5": "--brand-darker",
+  "6": "--ink",
+};
+
+export const participatingSites: ParticipatingSite[] = [
+  {
+    name: "HBT Medical College And Dr. R N Cooper Municipal General Hospital",
+    location: { lat: 19.10790971021016, lng: 72.83623768267398 },
+    city: "Mumbai",
+    state: "Maharashtra",
+    batch: "1",
+    website: "https://hbtmc.edu.in/",
+    pi: "Geeta Ghag, Vipul Nandu",
+    coordinators: "Snehal Jadhav",
+  },
+  {
+    name: "IPGME&R and SSKM Hospital",
+    location: { lat: 22.540269944753586, lng: 88.34186296554837 },
+    city: "Kolkata",
+    state: "West Bengal",
+    batch: "1",
+    website: "http://www.ipgmer.gov.in/",
+    pi: "Shamita Chatterjee, Maitreyee Mukherjee",
+    coordinators: "Sayeli Das",
+  },
+  {
+    name: "Christian Medical College & Hospital",
+    location: { lat: 30.911165478936997, lng: 75.86348436577856 },
+    city: "Ludhiana",
+    state: "Punjab",
+    batch: "1",
+    website: "https://www.cmcludhiana.in/",
+    pi: "Parvez Haque, Thejus Varghese",
+    coordinators: "Amandeep Kaur",
+  },
+  {
+    name: "Government Medical College & Hospital",
+    location: { lat: 30.692216564214863, lng: 76.7551942229613 },
+    city: "Chandigarh",
+    state: "Chandigarh",
+    batch: "1",
+    website: "https://www.gmch.gov.in/",
+    pi: "Rajeev Sharma",
+    coordinators: "Divya Sharma",
+  },
+  {
+    name: "Himalayan Institute of Medical Sciences",
+    location: { lat: 30.193327822632433, lng: 78.16497428998137 },
+    city: "Dehradun",
+    state: "Uttarakhand",
+    batch: "1",
+    website: "https://srhu.edu.in/medical-sciences/",
+    pi: "Hemant Nautiyal",
+    coordinators: "Anju Paliyal",
+  },
+  {
+    name: "Seth G.S. Medical College and King Edward Memorial Hospital",
+    location: { lat: 19.002633531934915, lng: 72.84142762699638 },
+    city: "Mumbai",
+    state: "Maharashtra",
+    batch: "2",
+    website: "https://www.kem.edu/",
+    pi: "Monty Khajanchi",
+    coordinators: "Snehal Jadhav",
+  },
+  {
+    name: "Lokmanya Tilak Municipal Medical College and General Hospital",
+    location: { lat: 19.036157387791466, lng: 72.85942328082004 },
+    city: "Mumbai",
+    state: "Maharashtra",
+    batch: "2",
+    website: "https://ltmgh.com/",
+    pi: "Vineet Kumar",
+    coordinators: "Snehal Jadhav",
+  },
+  {
+    name: "Holy Family Hospital",
+    location: { lat: 28.56218828970658, lng: 77.27511129639481 },
+    city: "New Delhi",
+    state: "Delhi",
+    batch: "2",
+    website: "https://www.hfhdelhi.org/",
+    pi: "Aisvarya Kapoor",
+    coordinators: "Himanshu Kumar",
+  },
+  {
+    name: "Assam Medical College & Hospital",
+    location: { lat: 27.483625508772267, lng: 94.94401488101919 },
+    city: "Dibrugarh",
+    state: "Assam",
+    batch: "2",
+    website: "https://amch-dibrugarh.assam.gov.in/",
+    pi: "Jishan Ahmed",
+    coordinators: "Noireeta Chetiapatra",
+  },
+  {
+    name: "Dayanand Medical College & Hospital",
+    location: { lat: 30.916655731118574, lng: 75.83081233862086 },
+    city: "Ludhiana",
+    state: "Punjab",
+    batch: "2",
+    website: "https://www.dmch.edu/",
+    pi: "Jaspal Singh",
+    coordinators: "Muskaan Katyal",
+  },
+];
+
+/**
+ * Batch windows follow the protocol: each batch runs 13 months with an
+ * anticipated 6-month overlap, starting from the trial start (Feb 2025).
+ */
+export const siteBatches: SiteBatchInfo[] = [
+  {
+    id: "1",
+    title: "Batch 1",
+    start: "2025-02",
+    end: "2026-03",
+    sites: participatingSites.filter((site) => site.batch === "1"),
+  },
+  {
+    id: "2",
+    title: "Batch 2",
+    start: "2025-12",
+    end: "2027-01",
+    sites: participatingSites.filter((site) => site.batch === "2"),
+  },
+  {
+    id: "3",
+    title: "Batch 3",
+    status: "starting",
+    sites: [],
+  },
+  {
+    id: "4",
+    title: "Batch 4",
+    status: "screening",
+    sites: [],
+  },
+  {
+    id: "5",
+    title: "Batch 5",
+    status: "screening",
+    sites: [],
+  },
+  {
+    id: "6",
+    title: "Batch 6",
+    status: "screening",
+    sites: [],
+  },
+];
+
+function parseYearMonth(value: string): { year: number; month: number } {
+  const [year, month] = value.split("-").map(Number);
+  return { year, month };
+}
+
+export function getBatchStatus(
+  batch: Pick<SiteBatchInfo, "start" | "end" | "status">,
+  now = new Date(),
+): BatchStatus {
+  if (batch.status) return batch.status;
+  if (!batch.start || !batch.end) return "upcoming";
+
+  const start = parseYearMonth(batch.start);
+  const end = parseYearMonth(batch.end);
+  const startDate = new Date(start.year, start.month - 1, 1);
+  const endDate = new Date(end.year, end.month, 0, 23, 59, 59, 999);
+
+  if (now < startDate) return "upcoming";
+  if (now > endDate) return "completed";
+  return "ongoing";
+}
+
+export const batchStatusLabels: Record<BatchStatus, string> = {
+  upcoming: "Upcoming",
+  ongoing: "Ongoing",
+  completed: "Completed",
+  starting: "Starting",
+  screening: "Screening clusters",
+};
+
+export const batchStatusPillClass: Record<BatchStatus, string> = {
+  upcoming: "status-pill status-pill--upcoming",
+  ongoing: "status-pill status-pill--live",
+  completed: "status-pill status-pill--completed",
+  starting: "status-pill status-pill--starting",
+  screening: "status-pill status-pill--screening",
+};
+
+/** Batches that currently have confirmed participating sites (for legend). */
+export function batchesWithSites(): SiteBatchInfo[] {
+  return siteBatches.filter((batch) => batch.sites.length > 0);
+}

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -4,11 +4,14 @@ import { createSteppedWedgeSvg, setRevealMonth, focusViewBox, viewBoxString, syn
 import { createForestPlot, type ForestPlotController } from "./forest-plot";
 import { designRevealStageMeta, startDesignReveal, type DesignRevealControls } from "./design-reveal";
 import { metaAnalysis, trialDesign, trialDesignStaircase } from "./figure-data";
+import { buildSitesLegendHtml, mountSitesMap, type SitesMapController } from "./sites-map";
+import { participatingSites } from "./data/sites";
 import "./style.css";
 
 let currentIndex = 0;
 let isAnimating = false;
 const forestControllers = new WeakMap<HTMLElement, ForestPlotController>();
+const sitesMapControllers = new WeakMap<HTMLElement, SitesMapController>();
 let designReveal: DesignRevealControls | null = null;
 
 const slidesEl = document.getElementById("slides")!;
@@ -413,6 +416,23 @@ function renderSlide(slide: Slide): HTMLElement {
       `;
       break;
 
+    case "sites-map":
+      el.innerHTML = `
+        <div class="slide-inner slide-inner--sites-map">
+          <header class="sites-map-header" data-animate>
+            <h2>${slide.title}</h2>
+            ${slide.subtitle ? `<p class="sites-map-subtitle">${slide.subtitle}</p>` : ""}
+          </header>
+          <div class="sites-legend" data-animate aria-label="Batch legend">
+            ${buildSitesLegendHtml()}
+            <span class="sites-legend__total">${participatingSites.length} hospitals</span>
+          </div>
+          <div class="sites-map" data-map role="region" aria-label="Participating sites map"></div>
+          ${slide.footer ? `<p class="slide-footer" data-animate>${slide.footer}</p>` : ""}
+        </div>
+      `;
+      break;
+
     case "team":
       el.innerHTML = `
         <div class="slide-inner slide-inner--team">
@@ -498,6 +518,15 @@ function mountSlides(): void {
         forestControllers.set(el, forest);
       }
     }
+    if (slide.layout === "sites-map") {
+      const mount = el.querySelector<HTMLElement>("[data-map]");
+      if (mount) {
+        void mountSitesMap(mount).then((controller) => {
+          sitesMapControllers.set(el, controller);
+          if (el.classList.contains("is-active")) controller.refresh();
+        });
+      }
+    }
   });
 }
 
@@ -571,6 +600,10 @@ function animateSlideIn(slideEl: HTMLElement): void {
     if (forest) {
       void forest.playChronologicalReveal();
     }
+  }
+
+  if (slideEl.dataset.layout === "sites-map") {
+    sitesMapControllers.get(slideEl)?.refresh();
   }
 
   const img = slideEl.querySelector<HTMLElement>(".slide-figure img, .visual-figure img");

--- a/presentations/atls-sweden-30-years/src/sites-map.ts
+++ b/presentations/atls-sweden-30-years/src/sites-map.ts
@@ -201,7 +201,7 @@ export async function mountSitesMap(container: HTMLElement): Promise<SitesMapCon
 
     const lat = sites.reduce((sum, s) => sum + s.location.lat, 0) / sites.length;
     const lng = sites.reduce((sum, s) => sum + s.location.lng, 0) / sites.length;
-    const labelSize = 22;
+    const labelSize = 36;
     const cityLabel = `${sites[0].city} (${sites.length} clusters)`;
 
     L.marker([lat, lng], {
@@ -213,7 +213,7 @@ export async function mountSitesMap(container: HTMLElement): Promise<SitesMapCon
         className: "sites-map__city-count",
         html: `<span class="sites-map__city-count-badge" aria-hidden="true">${sites.length}</span>`,
         iconSize: [labelSize, labelSize],
-        iconAnchor: [labelSize / 2, labelSize + markerSize / 2 + 2],
+        iconAnchor: [labelSize / 2, labelSize + markerSize / 2 + 4],
       }),
     }).addTo(map);
   }

--- a/presentations/atls-sweden-30-years/src/sites-map.ts
+++ b/presentations/atls-sweden-30-years/src/sites-map.ts
@@ -187,6 +187,37 @@ export async function mountSitesMap(container: HTMLElement): Promise<SitesMapCon
     markers.push(marker);
   }
 
+  // Count badge for cities with more than one participating cluster.
+  const sitesByCity = new Map<string, ParticipatingSite[]>();
+  for (const site of participatingSites) {
+    const key = `${site.city}|${site.state}`;
+    const group = sitesByCity.get(key);
+    if (group) group.push(site);
+    else sitesByCity.set(key, [site]);
+  }
+
+  for (const sites of sitesByCity.values()) {
+    if (sites.length < 2) continue;
+
+    const lat = sites.reduce((sum, s) => sum + s.location.lat, 0) / sites.length;
+    const lng = sites.reduce((sum, s) => sum + s.location.lng, 0) / sites.length;
+    const labelSize = 22;
+    const cityLabel = `${sites[0].city} (${sites.length} clusters)`;
+
+    L.marker([lat, lng], {
+      title: cityLabel,
+      interactive: false,
+      keyboard: false,
+      zIndexOffset: 500,
+      icon: L.divIcon({
+        className: "sites-map__city-count",
+        html: `<span class="sites-map__city-count-badge" aria-hidden="true">${sites.length}</span>`,
+        iconSize: [labelSize, labelSize],
+        iconAnchor: [labelSize / 2, labelSize + markerSize / 2 + 2],
+      }),
+    }).addTo(map);
+  }
+
   if (bounds.isValid()) {
     map.fitBounds(bounds, { padding: [mapPad, mapPad] });
   } else {

--- a/presentations/atls-sweden-30-years/src/sites-map.ts
+++ b/presentations/atls-sweden-30-years/src/sites-map.ts
@@ -201,7 +201,7 @@ export async function mountSitesMap(container: HTMLElement): Promise<SitesMapCon
 
     const lat = sites.reduce((sum, s) => sum + s.location.lat, 0) / sites.length;
     const lng = sites.reduce((sum, s) => sum + s.location.lng, 0) / sites.length;
-    const labelSize = 36;
+    const labelSize = 52;
     const cityLabel = `${sites[0].city} (${sites.length} clusters)`;
 
     L.marker([lat, lng], {
@@ -213,7 +213,7 @@ export async function mountSitesMap(container: HTMLElement): Promise<SitesMapCon
         className: "sites-map__city-count",
         html: `<span class="sites-map__city-count-badge" aria-hidden="true">${sites.length}</span>`,
         iconSize: [labelSize, labelSize],
-        iconAnchor: [labelSize / 2, labelSize + markerSize / 2 + 4],
+        iconAnchor: [labelSize / 2, labelSize + markerSize / 2 + 6],
       }),
     }).addTo(map);
   }

--- a/presentations/atls-sweden-30-years/src/sites-map.ts
+++ b/presentations/atls-sweden-30-years/src/sites-map.ts
@@ -15,9 +15,16 @@ import {
   type ParticipatingSite,
 } from "./data/sites";
 
-const TILE_URL = "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+/**
+ * Esri World Light Gray — free light basemap suitable for a presentation deck.
+ * CARTO Positron (used on advancetrauma.info) now watermarks tiles without an
+ * API key; Esri keeps the same clean look without a key for this use case.
+ * Note Esri’s {z}/{y}/{x} path order (not {z}/{x}/{y}).
+ */
+const TILE_URL =
+  "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}";
 const TILE_ATTRIBUTION =
-  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>';
+  'Tiles &copy; <a href="https://www.esri.com/">Esri</a> &mdash; Esri, DeLorme, NAVTEQ';
 
 function cssVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -140,8 +147,7 @@ export async function mountSitesMap(container: HTMLElement): Promise<SitesMapCon
 
   L.tileLayer(TILE_URL, {
     attribution: TILE_ATTRIBUTION,
-    subdomains: "abcd",
-    maxZoom: 20,
+    maxZoom: 16,
   }).addTo(map);
 
   const bounds = L.latLngBounds([]);

--- a/presentations/atls-sweden-30-years/src/sites-map.ts
+++ b/presentations/atls-sweden-30-years/src/sites-map.ts
@@ -1,0 +1,208 @@
+/**
+ * Leaflet map of participating clusters — adapted from
+ * advancetrauma.info `SitesMap` for this vanilla Vite presentation.
+ */
+
+import type { Map as LeafletMap, Marker as LeafletMarker } from "leaflet";
+import {
+  batchColorTokens,
+  batchStatusLabels,
+  batchStatusPillClass,
+  batchesWithSites,
+  getBatchStatus,
+  participatingSites,
+  siteBatches,
+  type ParticipatingSite,
+} from "./data/sites";
+
+const TILE_URL = "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+const TILE_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>';
+
+function cssVar(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function safeHttpUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function buildSitePopupHtml(site: ParticipatingSite): string {
+  const batch = siteBatches.find((item) => item.id === site.batch)!;
+  const status = getBatchStatus(batch);
+  const websiteHref = safeHttpUrl(site.website);
+  const websiteLink = websiteHref
+    ? `<a class="sites-map-popup__link" href="${escapeHtml(websiteHref)}" target="_blank" rel="noopener noreferrer">Visit website</a>`
+    : "";
+  const coordinators = site.coordinators
+    ? `<p class="sites-map-popup__row">
+        <span class="sites-map-popup__label">Clinical research coordinator</span>
+        ${escapeHtml(site.coordinators)}
+      </p>`
+    : "";
+
+  return `
+    <div class="sites-map-popup__body">
+      <h3 class="sites-map-popup__title">${escapeHtml(site.name)}</h3>
+      <div class="sites-map-popup__pills">
+        <span class="sites-map-popup__pill sites-map-popup__pill--batch" style="background: var(${batchColorTokens[site.batch]});">Batch ${escapeHtml(site.batch)}</span>
+        <span class="${batchStatusPillClass[status]}">${escapeHtml(batchStatusLabels[status])}</span>
+      </div>
+      <p class="sites-map-popup__row">
+        <span class="sites-map-popup__label">Investigator</span>
+        ${escapeHtml(site.pi)}
+      </p>
+      ${coordinators}
+      <p class="sites-map-popup__row">
+        <span class="sites-map-popup__label">Location</span>
+        ${escapeHtml(site.city)}, ${escapeHtml(site.state)}
+      </p>
+      ${websiteLink}
+    </div>
+  `;
+}
+
+function createSitePopupElement(bodyHtml: string, onClose: () => void): HTMLElement {
+  const popup = document.createElement("div");
+  popup.className = "sites-map__popup";
+  popup.setAttribute("role", "dialog");
+  popup.innerHTML = `
+    <button type="button" class="sites-map__popup-close" aria-label="Close">×</button>
+    ${bodyHtml}
+  `;
+
+  const closeBtn = popup.querySelector(".sites-map__popup-close");
+  closeBtn?.addEventListener("click", (event) => {
+    event.stopPropagation();
+    onClose();
+  });
+  popup.addEventListener("click", (event) => {
+    event.stopPropagation();
+  });
+
+  return popup;
+}
+
+export function buildSitesLegendHtml(): string {
+  return batchesWithSites()
+    .map((batch) => {
+      const status = getBatchStatus(batch);
+      return `
+        <span class="sites-legend__item">
+          <span class="sites-legend__swatch" style="background: var(${batchColorTokens[batch.id]});" aria-hidden="true"></span>
+          ${escapeHtml(batch.title)}
+          <span class="${batchStatusPillClass[status]}">${escapeHtml(batchStatusLabels[status])}</span>
+          <span class="sites-legend__count">${batch.sites.length}</span>
+        </span>`;
+    })
+    .join("");
+}
+
+export type SitesMapController = {
+  refresh: () => void;
+  destroy: () => void;
+};
+
+/**
+ * Mount a Leaflet map into `container`. Safe to call while the slide is hidden;
+ * call `refresh()` when the slide becomes active so Leaflet remeasures size.
+ */
+export async function mountSitesMap(container: HTMLElement): Promise<SitesMapController> {
+  const [{ default: L }] = await Promise.all([
+    import("leaflet"),
+    import("leaflet/dist/leaflet.css"),
+  ]);
+
+  const textInverse = cssVar("--text-inverse") || "#ffffff";
+  const markerSize = Number.parseFloat(cssVar("--map-marker-size-px")) || 28;
+  const popupWidth = Number.parseFloat(cssVar("--map-popup-width-px")) || 280;
+  const mapPad = Number.parseFloat(cssVar("--map-fit-padding-px")) || 24;
+
+  const map: LeafletMap = L.map(container, {
+    scrollWheelZoom: false,
+    attributionControl: true,
+  });
+
+  L.tileLayer(TILE_URL, {
+    attribution: TILE_ATTRIBUTION,
+    subdomains: "abcd",
+    maxZoom: 20,
+  }).addTo(map);
+
+  const bounds = L.latLngBounds([]);
+  const markers: LeafletMarker[] = [];
+
+  for (const site of participatingSites) {
+    const markerColor = cssVar(batchColorTokens[site.batch]) || "#1a9dbb";
+    const icon = L.divIcon({
+      className: "sites-map__leaflet-marker",
+      html: `
+        <svg width="${markerSize}" height="${markerSize}" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="16" cy="16" r="12" fill="${markerColor}" stroke="${textInverse}" stroke-width="2"/>
+          <circle cx="16" cy="16" r="6" fill="${textInverse}"/>
+        </svg>
+      `,
+      iconSize: [markerSize, markerSize],
+      iconAnchor: [markerSize / 2, markerSize / 2],
+      popupAnchor: [0, -(markerSize / 2 - 2)],
+    });
+
+    const popupHtml = buildSitePopupHtml(site);
+    const marker = L.marker([site.location.lat, site.location.lng], {
+      title: site.name,
+      icon,
+    })
+      .bindPopup(
+        () => createSitePopupElement(popupHtml, () => marker.closePopup()),
+        {
+          maxWidth: popupWidth,
+          className: "sites-map__leaflet-popup",
+          closeButton: false,
+        },
+      )
+      .addTo(map);
+
+    bounds.extend([site.location.lat, site.location.lng]);
+    markers.push(marker);
+  }
+
+  if (bounds.isValid()) {
+    map.fitBounds(bounds, { padding: [mapPad, mapPad] });
+  } else {
+    map.setView([20.5937, 78.9629], 5);
+  }
+
+  const refresh = () => {
+    requestAnimationFrame(() => {
+      map.invalidateSize();
+      if (bounds.isValid()) {
+        map.fitBounds(bounds, { padding: [mapPad, mapPad] });
+      }
+    });
+  };
+
+  refresh();
+
+  return {
+    refresh,
+    destroy: () => {
+      map.remove();
+      markers.length = 0;
+    },
+  };
+}

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -61,7 +61,8 @@ export interface Slide {
     | "aim"
     | "presenter"
     | "team"
-    | "funding";
+    | "funding"
+    | "sites-map";
   title?: string;
   subtitle?: string;
   eyebrow?: string;
@@ -450,6 +451,13 @@ export const slides: Slide[] = [
       { value: "May 2026", label: "third batch planned" },
     ],
     footer: "Expected completion December 2028, pending funding",
+  },
+  {
+    id: "participating-clusters",
+    layout: "sites-map",
+    title: "Participating clusters",
+    subtitle: "Hospitals currently in the trial",
+    footer: "Batches 1–2 confirmed · Batches 3–6 screening · Full list at advancetrauma.info",
   },
   {
     id: "implications",

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1521,17 +1521,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 52px;
+  height: 52px;
   border-radius: 50%;
   background: var(--ink);
   color: var(--text-inverse);
   font-family: var(--font-display);
-  font-size: 1.05rem;
+  font-size: 1.5rem;
   font-weight: 700;
   line-height: 1;
-  border: 2px solid var(--text-inverse);
-  box-shadow: 0 1px 4px var(--shadow-ink-soft);
+  border: 3px solid var(--text-inverse);
+  box-shadow: 0 2px 6px var(--shadow-ink-soft);
 }
 
 .sites-map__leaflet-popup .leaflet-popup-content-wrapper {

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -6,20 +6,34 @@
   --brand-darker: #12788f;
   --accent: #f6851f;
   --accent-deep: #e07510;
+  --accent-hover: #663996;
   --intervention: #7b5ea7;
+  --status-live: #1f9d55;
+  --light-blue: #8ecbe8;
   --surface: #ffffff;
   --surface-muted: #f4fafc;
+  --surface-map: #e8f4f7;
   --ink: #082830;
   --text: #1a2a30;
   --text-muted: #4a5c64;
   --text-inverse: #ffffff;
   --border: #d5e3e8;
+  --shadow-ink-soft: color-mix(in srgb, var(--ink) 18%, transparent);
   --font-display: "Quicksand", system-ui, sans-serif;
   --font-heading: "EB Garamond", Georgia, serif;
   --font-body: "Roboto", system-ui, sans-serif;
   --radius: 4px;
+  --radius-md: 6px;
+  --radius-pill: 999px;
   --slide-padding: clamp(1.5rem, 4vw, 3rem);
   --transition-smooth: cubic-bezier(0.22, 1, 0.36, 1);
+  --map-height: min(62vh, 28rem);
+  --map-marker-size: 1.75rem;
+  --map-marker-size-px: 28;
+  --map-popup-width: 17.5rem;
+  --map-popup-width-px: 280;
+  --map-popup-max-height: 22rem;
+  --map-fit-padding-px: 28;
 }
 
 *,
@@ -1408,6 +1422,238 @@ body {
 
 .implication-card strong {
   color: var(--ink);
+}
+
+/* ── Participating clusters map ─────────────────────────────────── */
+
+.slide-inner--sites-map {
+  display: flex;
+  flex-direction: column;
+  max-width: 1100px;
+  min-height: 100%;
+}
+
+.sites-map-header {
+  margin-bottom: 0.65rem;
+}
+
+.sites-map-header h2 {
+  margin-bottom: 0.2em;
+}
+
+.sites-map-subtitle {
+  font-family: var(--font-heading);
+  font-size: clamp(1.05rem, 2.2vw, 1.35rem);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.sites-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.sites-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.sites-legend__swatch {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  border: 2px solid var(--text-inverse);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ink) 20%, transparent);
+  flex-shrink: 0;
+}
+
+.sites-legend__count {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.sites-legend__count::before {
+  content: "· ";
+}
+
+.sites-legend__total {
+  margin-left: auto;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.sites-map {
+  width: 100%;
+  height: var(--map-height);
+  flex: 1 1 auto;
+  min-height: 16rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-map);
+  z-index: 0;
+  overflow: hidden;
+}
+
+.sites-map.leaflet-container {
+  font: inherit;
+}
+
+.sites-map__leaflet-marker {
+  background: transparent;
+  border: 0;
+}
+
+.sites-map__leaflet-popup .leaflet-popup-content-wrapper {
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.sites-map__leaflet-popup .leaflet-popup-content {
+  margin: 0;
+  min-width: 0;
+}
+
+.sites-map__leaflet-popup .leaflet-popup-tip-container {
+  display: none;
+}
+
+.sites-map__popup {
+  position: relative;
+  max-width: min(var(--map-popup-width), calc(100% - 1rem));
+  max-height: var(--map-popup-max-height);
+  overflow: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px var(--shadow-ink-soft);
+}
+
+.sites-map__popup-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  z-index: 1;
+  width: var(--map-marker-size);
+  height: var(--map-marker-size);
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 1.125rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.sites-map-popup__body {
+  padding: 1rem;
+  max-width: var(--map-popup-width);
+  font-family: var(--font-body);
+}
+
+.sites-map-popup__title {
+  margin: 0 1.25rem 0.5rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--brand);
+}
+
+.sites-map-popup__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.55rem;
+}
+
+.sites-map-popup__pill {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.sites-map-popup__pill--batch {
+  color: var(--text-inverse);
+}
+
+.sites-map-popup__row {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--text);
+}
+
+.sites-map-popup__label {
+  display: block;
+  margin-bottom: 0.15rem;
+  font-size: 0.7rem;
+  font-weight: 300;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.sites-map-popup__link {
+  display: inline-block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--brand);
+  text-decoration: none;
+  border-bottom: 1px solid var(--brand);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.status-pill--live {
+  background: var(--status-live);
+  color: var(--text-inverse);
+}
+
+.status-pill--upcoming {
+  background: var(--light-blue);
+  color: var(--brand-deep);
+}
+
+.status-pill--completed {
+  background: var(--border);
+  color: var(--text-muted);
+}
+
+.status-pill--starting {
+  background: var(--brand);
+  color: var(--text-inverse);
+}
+
+.status-pill--screening {
+  background: var(--light-blue);
+  color: var(--brand-deep);
 }
 
 /* ── Team ───────────────────────────────────────────────────────── */

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1521,13 +1521,13 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   background: var(--ink);
   color: var(--text-inverse);
   font-family: var(--font-display);
-  font-size: 0.72rem;
+  font-size: 1.05rem;
   font-weight: 700;
   line-height: 1;
   border: 2px solid var(--text-inverse);

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1512,6 +1512,28 @@ body {
   border: 0;
 }
 
+.sites-map__city-count {
+  background: transparent;
+  border: 0;
+}
+
+.sites-map__city-count-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--text-inverse);
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  border: 2px solid var(--text-inverse);
+  box-shadow: 0 1px 4px var(--shadow-ink-soft);
+}
+
 .sites-map__leaflet-popup .leaflet-popup-content-wrapper {
   padding: 0;
   background: transparent;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an interactive map of currently participating hospital clusters to the ATLS Sweden 30-year deck.

## Changes
- New `#participating-clusters` slide after **Current status**, showing Batches 1–2 hospitals on a Leaflet map (same marker/popup pattern as [advancetrauma.info](https://www.advancetrauma.info))
- Batch-coloured markers with popups (site name, investigators, coordinators, location, website)
- Legend with batch status pills and hospital count
- Large count badges for cities with more than one cluster (Mumbai **3**, Ludhiana **2**)
- Site data mirrored from the website `sites.ts` for easy sync
- Esri World Light Gray basemap (CARTO Positron now watermarks without an API key)

## Demo

[Larger city count badges on the clusters map](https://cursor.com/agents/bc-086612d3-200c-44cf-8c29-49ecea1a22f0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fparticipating-clusters-larger-counts.webp)

[clusters-map-city-count-labels.mp4](https://cursor.com/agents/bc-086612d3-200c-44cf-8c29-49ecea1a22f0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclusters-map-city-count-labels.mp4)

## Notes
- Map is lazy-loaded via Leaflet and remeasured when the slide becomes active
- Batches 3–6 remain screening (no markers yet), matching the live site


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-086612d3-200c-44cf-8c29-49ecea1a22f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-086612d3-200c-44cf-8c29-49ecea1a22f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

