### PR TITLE
Add eligibility criteria slide to ATLS Sweden 30 years presentation

### DIFF
--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -46,6 +46,7 @@ Image assets in `public/` are copied to `dist/` during build:
 | — | `atls-impact-sources` | Historical sources for manual Impact claims |
 | — | `atls-forest` | Updated systematic review forest plot |
 | 12–21 | Trial slides | Design, nested staircase, outcomes, status |
+| — | `eligibility` | Cluster and patient eligibility criteria |
 | — | `implications` | Take-home messages |
 | — | `team` | International collaboration overview |
 | — | `funding` | Current funders and funding gap |

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -281,6 +281,28 @@ function renderSlide(slide: Slide): HTMLElement {
       `;
       break;
 
+    case "columns":
+      el.innerHTML = `
+        <div class="slide-inner slide-inner--columns">
+          <h2 data-animate>${slide.title}</h2>
+          <div class="columns-grid" data-animate-group>
+            ${(slide.columns ?? [])
+              .map(
+                (col) => `
+              <article class="column-card" data-animate>
+                <h3 class="column-card__heading">${col.heading}</h3>
+                <ul class="bullet-list">
+                  ${col.bullets.map((b) => `<li>${b}</li>`).join("")}
+                </ul>
+              </article>`
+              )
+              .join("")}
+          </div>
+          ${slide.footer ? `<p class="slide-footer" data-animate>${slide.footer}</p>` : ""}
+        </div>
+      `;
+      break;
+
     case "milestones":
       el.innerHTML = `
         <div class="slide-inner slide-inner--milestones">
@@ -527,7 +549,10 @@ function thumbPreviewClass(slide: Slide): string {
 function thumbPreviewInner(slide: Slide): string {
   const label = slideThumbLabel(slide);
   const chips =
-    slide.layout === "stats" || slide.layout === "evidence" || slide.layout === "milestones"
+    slide.layout === "stats" ||
+    slide.layout === "evidence" ||
+    slide.layout === "milestones" ||
+    slide.layout === "columns"
       ? `<div class="overview-thumb__chips" aria-hidden="true">
           <span class="overview-thumb__chip"></span>
           <span class="overview-thumb__chip overview-thumb__chip--accent"></span>

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -39,6 +39,11 @@ export interface Funder {
   name: string;
 }
 
+export interface ColumnGroup {
+  heading: string;
+  bullets: string[];
+}
+
 export interface Slide {
   id: string;
   layout:
@@ -60,7 +65,8 @@ export interface Slide {
     | "aim"
     | "presenter"
     | "team"
-    | "funding";
+    | "funding"
+    | "columns";
   title?: string;
   subtitle?: string;
   eyebrow?: string;
@@ -78,6 +84,7 @@ export interface Slide {
   milestones?: Milestone[];
   teamGroups?: TeamGroup[];
   funders?: Funder[];
+  columns?: ColumnGroup[];
   /** Which exported trial-design JSON to render on design slides. */
   designVariant?: "main" | "staircase";
 }
@@ -422,6 +429,28 @@ export const slides: Slide[] = [
       "Adherence measured around each hospital’s transition to ATLS®",
       "Pre- and post-transition staircase periods nested in the stepped wedge",
       "Lets us compare process adherence before and after training within clusters",
+    ],
+  },
+  {
+    id: "eligibility",
+    layout: "columns",
+    title: "Eligibility criteria",
+    columns: [
+      {
+        heading: "Cluster",
+        bullets: [
+          "Hospitals that admit or refer/transfer for admission at least 400 patients with trauma per year",
+          "Around-the-clock emergency surgical and orthopaedic services",
+        ],
+      },
+      {
+        heading: "Patient",
+        bullets: [
+          "Adult trauma patients presenting to the emergency department of participating hospitals with a history of trauma",
+          "Admitted, dies before admission, or transferred for admission",
+          "Less than 48 hours since trauma",
+        ],
+      },
     ],
   },
   {

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -757,6 +757,50 @@ body {
   }
 }
 
+/* ── Columns (e.g. eligibility) ─────────────────────────────────── */
+
+.slide-inner--columns {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100%;
+}
+
+.columns-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .columns-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.column-card {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-top: 4px solid var(--brand);
+  border-radius: var(--radius);
+  padding: clamp(1.1rem, 2.2vw, 1.5rem);
+}
+
+.column-card__heading {
+  font-family: var(--font-display);
+  font-size: clamp(1.15rem, 2.2vw, 1.4rem);
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.01em;
+}
+
+.column-card .bullet-list li {
+  font-size: clamp(0.95rem, 1.7vw, 1.1rem);
+  line-height: 1.45;
+}
+
 .slide-figure {
   margin: 0;
   display: flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an **Eligibility criteria** slide to the ATLS Sweden 30 years web deck, adapted from the trial meeting PPTX.

### Changes
- New `columns` layout (two heading + bullet groups) for Cluster and Patient criteria
- Slide placed after Nested staircase / before Sample size, matching the source deck order
- README slide overview updated

### Content
- **Cluster:** ≥400 trauma admissions/referrals per year; 24/7 surgical and orthopaedic emergency services
- **Patient:** Adult trauma presentations; admitted / dies before admission / transferred for admission; &lt;48 hours since trauma

### Verification
- Typecheck and production build pass
- Manually verified at `#eligibility` (slide 23/29)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1aba1302-d334-4c84-96d7-4a8e18f39faf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aba1302-d334-4c84-96d7-4a8e18f39faf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

