### PR TITLE
Align Previous work slide styling and add full citations

### DIFF
--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -340,10 +340,8 @@ function renderSlide(slide: Slide): HTMLElement {
     case "milestones":
       el.innerHTML = `
         <div class="slide-inner slide-inner--milestones">
-          <header class="milestones-header" data-animate>
-            <h2>${slide.title}</h2>
-            ${slide.subtitle ? `<p class="milestones-subtitle">${slide.subtitle}</p>` : ""}
-          </header>
+          <h2 data-animate>${slide.title}</h2>
+          ${slide.subtitle ? `<p class="milestones-subtitle" data-animate>${slide.subtitle}</p>` : ""}
           <div class="milestones-grid" data-animate-group>
             ${(slide.milestones ?? [])
               .map(
@@ -368,6 +366,15 @@ function renderSlide(slide: Slide): HTMLElement {
               )
               .join("")}
           </div>
+          ${
+            slide.references?.length
+              ? `<ol class="slide-references" data-animate>
+                  ${slide.references
+                    .map((ref) => `<li value="${ref.id}"><span class="ref-marker">${ref.id}.</span> ${ref.text}</li>`)
+                    .join("")}
+                </ol>`
+              : ""
+          }
         </div>
       `;
       break;

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -346,31 +346,49 @@ export const slides: Slide[] = [
     milestones: [
       {
         year: "2013",
-        label: "Multicentre research",
+        label: "Multicentre research — TITCO Consortium",
         image: "./milestones/multicentre.png",
         imageAlt: "Map of India with hospital sites",
-        cite: "12",
+        cite: "1",
       },
       {
         year: "2022–2023",
-        label: "Pilot and feasibility study",
+        label: "Pilot and feasibility — Gerdin Wärnberg et al. BMJ Open 2025",
         image: "./milestones/pilot.png",
         imageAlt: "Clinicians discussing care in a hospital room",
-        cite: "14",
+        cite: "2",
       },
       {
         year: "2022–2023",
-        label: "Community consultations",
+        label: "Community consultations — David & Gerdin Wärnberg 2024",
         image: "./milestones/consultations.png",
         imageAlt: "Patient bedside discussion about ATLS",
-        cite: "13",
+        cite: "3",
       },
       {
         year: "2022–2026",
-        label: "Systematic review",
+        label: "Systematic review — Nakhid et al. 2026",
         image: "./milestones/systematic-review.png",
         imageAlt: "Nakhid et al. systematic review article in press",
-        cite: "5",
+        cite: "4",
+      },
+    ],
+    references: [
+      {
+        id: "1",
+        text: "TITCO Consortium. Towards Improved Trauma Care Outcomes in India. www.titco.org.",
+      },
+      {
+        id: "2",
+        text: "Gerdin Wärnberg M et al. Feasibility of a cluster randomised trial on the effect of trauma life support training: a pilot study in India. BMJ Open. 2025;15:e099020.",
+      },
+      {
+        id: "3",
+        text: "David S, Gerdin Wärnberg M, TERN Collaborators. Patient-reported outcomes relevant to post-discharge trauma patients in urban India. medRxiv. 2024.",
+      },
+      {
+        id: "4",
+        text: "Nakhid Z et al. Effect of trauma life support training on patient outcomes: a systematic review and meta-analysis. Scand J Trauma Resusc Emerg Med. 2026.",
       },
     ],
   },

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1033,7 +1033,7 @@ body {
   padding: 0.85rem 1rem;
   background: var(--surface-muted);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius);
   transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
 }
 

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -995,36 +995,29 @@ body {
 .slide-inner--milestones {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   min-height: 100%;
 }
 
-.milestones-header {
-  text-align: center;
-  margin-bottom: 1.75rem;
-}
-
 .slide--milestones .slide-inner--milestones h2 {
-  border-bottom: none;
-  padding-bottom: 0;
-  margin-bottom: 0.25rem;
-  text-align: center;
+  margin-bottom: 0.35rem;
 }
 
 .milestones-subtitle {
+  margin: 0 0 1.5rem;
   font-family: var(--font-body);
-  font-size: clamp(0.95rem, 1.8vw, 1.15rem);
+  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
   color: var(--text-muted);
   font-weight: 400;
+  line-height: 1.4;
 }
 
 .milestones-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: clamp(1.25rem, 3vw, 2.25rem) clamp(1.5rem, 4vw, 3rem);
-  max-width: 980px;
-  margin: 0 auto;
+  gap: clamp(1rem, 2.5vw, 1.75rem) clamp(1.25rem, 3.5vw, 2.5rem);
   width: 100%;
+  flex: 1;
+  align-content: center;
 }
 
 @media (max-width: 700px) {
@@ -1037,20 +1030,30 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
+}
+
+.milestone-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(26, 157, 187, 0.12);
 }
 
 .milestone-card__media {
   flex-shrink: 0;
-  width: clamp(5.5rem, 12vw, 7.5rem);
-  height: clamp(5.5rem, 12vw, 7.5rem);
+  width: clamp(4.75rem, 10vw, 6.5rem);
+  height: clamp(4.75rem, 10vw, 6.5rem);
   margin: 0;
   border-radius: 50%;
   overflow: hidden;
-  background: var(--surface-muted);
-  border: 3px solid var(--surface);
+  background: var(--surface);
+  border: 2px solid var(--surface);
   box-shadow:
     0 0 0 1px var(--border),
-    0 8px 24px rgba(8, 40, 48, 0.1);
+    0 6px 18px rgba(8, 40, 48, 0.08);
 }
 
 .milestone-card__media img {
@@ -1069,7 +1072,7 @@ body {
 
 .milestone-card__year {
   font-family: var(--font-display);
-  font-size: clamp(1.05rem, 2vw, 1.25rem);
+  font-size: clamp(1rem, 1.9vw, 1.2rem);
   font-weight: 600;
   color: var(--brand-deep);
   line-height: 1.2;
@@ -1077,10 +1080,15 @@ body {
 
 .milestone-card__label {
   font-family: var(--font-body);
-  font-size: clamp(0.95rem, 1.8vw, 1.15rem);
+  font-size: clamp(0.88rem, 1.6vw, 1.05rem);
   font-weight: 500;
   color: var(--ink);
   line-height: 1.35;
+}
+
+.slide-inner--milestones .slide-references {
+  margin-top: auto;
+  padding-top: 1rem;
 }
 
 /* ── Design / stepped wedge ─────────────────────────────────────── */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update the Previous work slide in the ATLS Sweden 30-year presentation so it matches the rest of the deck and includes full citations like the Global burden / Scope of the problem slide.

### Changes
- Restyle the milestones layout: left-aligned title with standard heading rule, muted subtitle, and light card treatment consistent with other content slides
- Renumber in-slide citation markers to 1–4
- Add a footer reference list with full citations for TITCO, the pilot/feasibility study, community consultations, and the Nakhid et al. systematic review
- Expand milestone labels with short citation forms for readability alongside the numbered footnotes

### Testing
- Visual check of `#previous-work` against `#trauma-stats` in the Vite preview

[Updated Previous work slide](https://cursor.com/agents/bc-5e0f6226-1171-4425-ba5c-441e6c8dea06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprevious_work_slide_updated.webp)
[Scope of the problem references for comparison](https://cursor.com/agents/bc-5e0f6226-1171-4425-ba5c-441e6c8dea06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscope_of_problem_references_comparison.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e0f6226-1171-4425-ba5c-441e6c8dea06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e0f6226-1171-4425-ba5c-441e6c8dea06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

