### PR TITLE
Polish Study design slide look and feel

### DIFF
--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -1,6 +1,13 @@
 import { animate, stagger } from "motion";
 import { slides, type Slide } from "./slides";
-import { createSteppedWedgeSvg, setRevealMonth, focusViewBox, viewBoxString, syncAxisToStage } from "./stepped-wedge";
+import {
+  createSteppedWedgeSvg,
+  createWedgeLegend,
+  setRevealMonth,
+  focusViewBox,
+  viewBoxString,
+  syncAxisToStage,
+} from "./stepped-wedge";
 import { createForestPlot, type ForestPlotController } from "./forest-plot";
 import { designRevealStageMeta, startDesignReveal, type DesignRevealControls } from "./design-reveal";
 import { createSequencesChart, createSequencesLegend } from "./sequences";
@@ -374,13 +381,47 @@ function renderSlide(slide: Slide): HTMLElement {
 
     case "design":
       el.innerHTML = `
-        <div class="slide-inner">
+        <div class="slide-inner slide-inner--design">
           <h2 data-animate>${slide.title}</h2>
           <div class="design-layout">
-            <ul class="bullet-list design-bullets" data-animate-group>
-              ${(slide.bullets ?? []).map((b) => `<li data-animate>${b}</li>`).join("")}
-            </ul>
-            <div class="wedge-container" data-animate id="wedge-mount"></div>
+            <div class="design-copy" data-animate-group>
+              ${
+                slide.body
+                  ? `<p class="design-lead" data-animate>${slide.body}</p>`
+                  : ""
+              }
+              ${
+                slide.stats?.length
+                  ? `<div class="design-metrics" data-animate>
+                      ${slide.stats
+                        .map(
+                          (s) => `
+                        <div class="design-metric">
+                          <span class="stat-value">${s.value}</span>
+                          <span class="stat-label">${s.label}</span>
+                        </div>`
+                        )
+                        .join("")}
+                    </div>`
+                  : ""
+              }
+              ${
+                slide.bullets?.length
+                  ? `<ul class="bullet-list design-bullets" data-animate-group>
+                      ${slide.bullets.map((b) => `<li data-animate>${b}</li>`).join("")}
+                    </ul>`
+                  : ""
+              }
+              ${
+                slide.footer
+                  ? `<p class="design-note" data-animate>${slide.footer}</p>`
+                  : ""
+              }
+            </div>
+            <div class="design-figure" data-animate>
+              <div class="wedge-legend-mount"></div>
+              <div class="wedge-container" id="wedge-mount"></div>
+            </div>
           </div>
         </div>
       `;
@@ -571,6 +612,8 @@ function mountSlides(): void {
         if (slide.layout === "design") {
           const data = slide.designVariant === "staircase" ? trialDesignStaircase : trialDesign;
           mount.appendChild(createSteppedWedgeSvg(data));
+          const legendMount = el.querySelector(".wedge-legend-mount");
+          if (legendMount) legendMount.appendChild(createWedgeLegend(data));
         }
         // design-animation chart is mounted by startDesignReveal.
       }

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -379,11 +379,14 @@ export const slides: Slide[] = [
     layout: "design",
     title: "Study design",
     designVariant: "main",
-    bullets: [
-      "Batched stepped-wedge cluster randomised trial",
-      "30 hospitals · 6 batches · 5 sequences · 13 months in trial",
-      "Conducted in India — ongoing collaborations >10 years; ATLS not yet standard",
+    body: "Batched stepped-wedge cluster randomised trial",
+    stats: [
+      { value: "30", label: "hospitals" },
+      { value: "6", label: "batches" },
+      { value: "5", label: "sequences" },
+      { value: "13", label: "months in trial" },
     ],
+    footer: "Conducted in India — ongoing collaborations >10 years; ATLS® not yet standard",
   },
   {
     id: "design-animation",

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1085,17 +1085,90 @@ body {
 
 /* ── Design / stepped wedge ─────────────────────────────────────── */
 
+.slide-inner--design {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100%;
+  max-width: 1180px;
+}
+
+.slide-inner--design > h2 {
+  margin-bottom: 1.15rem;
+}
+
 .design-layout {
   display: grid;
-  grid-template-columns: 1fr 1.4fr;
-  gap: 2rem;
-  align-items: start;
+  grid-template-columns: minmax(16rem, 0.95fr) minmax(0, 1.35fr);
+  gap: clamp(1.5rem, 3.5vw, 2.75rem);
+  align-items: center;
 }
 
 @media (max-width: 900px) {
   .design-layout {
     grid-template-columns: 1fr;
+    align-items: stretch;
   }
+}
+
+.design-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+  min-width: 0;
+}
+
+.design-lead {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.25rem, 2.4vw, 1.7rem);
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+  padding: 0.85rem 0 0.85rem 1rem;
+  border-left: 3px solid var(--accent);
+}
+
+.design-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem 1.25rem;
+  padding: 0.15rem 0 0.15rem 1rem;
+}
+
+.design-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.design-metric .stat-value {
+  font-size: clamp(1.65rem, 3.4vw, 2.35rem);
+}
+
+.design-metric .stat-label {
+  font-size: clamp(0.82rem, 1.5vw, 0.95rem);
+}
+
+.design-note {
+  margin: 0;
+  padding: 0.85rem 0 0 1rem;
+  border-top: 1px solid var(--border);
+  font-size: clamp(0.9rem, 1.6vw, 1.05rem);
+  color: var(--text-muted);
+  line-height: 1.45;
+  max-width: 36ch;
+}
+
+.design-copy .design-bullets {
+  padding-left: 0;
+}
+
+.design-copy .design-bullets li {
+  font-size: clamp(0.95rem, 1.7vw, 1.1rem);
+  line-height: 1.4;
 }
 
 .design-bullets li {
@@ -1110,6 +1183,25 @@ body {
 
 .design-bullets li.is-muted {
   opacity: 0.45;
+}
+
+.design-figure {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.design-figure .wedge-legend-mount {
+  order: 1;
+}
+
+.design-figure .wedge-container {
+  order: 0;
+}
+
+.design-figure .wedge-legend {
+  justify-content: center;
 }
 
 .wedge-panel {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the ATLS Sweden 30-year **Study design** slide so it matches the rest of the deck more closely—clear hierarchy and brand metrics, without turning the left column into a card stack.

## Changes
- Lead with the trial design statement (accent rule, display type)
- Surface 30 / 6 / 5 / 13 as compact brand metrics instead of a dense bullet
- Keep the India context as a quieter supporting note
- Pair the stepped-wedge figure with the existing legend component
- Vertically center the two-column composition; staircase design slide keeps bullets but gets the same figure treatment

## Test plan
- [x] Open `#design` and confirm layout matches neighboring content slides
- [x] Confirm `#design-staircase` still renders bullets + chart + legend
- [x] Confirm enter animation still plays on the wedge segments
- [ ] Check mobile/narrow width stacks cleanly (CSS media query present; not manually resized in this run)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27d98ed0-9276-4898-a91d-9fcad95ca03a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27d98ed0-9276-4898-a91d-9fcad95ca03a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

