### PR TITLE
Unify ATLS Sweden 30-year presentation design language

### DIFF
--- a/presentations/atls-sweden-30-years/README.md
+++ b/presentations/atls-sweden-30-years/README.md
@@ -55,6 +55,10 @@ Image assets in `public/` are copied to `dist/` during build:
 | — | `funding` | Current funders and funding gap |
 | — | `closing` | Thank you |
 
+## Speaker briefing
+
+`qa-and-panel-briefing.md` — anticipated critical questions after the talk and in the future-of-trauma-care panel, with suggested replies (Sweden · Region 15 · US audience).
+
 ## Source
 
 Content adapted from `presentation.pptx` (trial meeting deck), tailored for an international ATLS audience celebrating 30 years of the Swedish chapter.

--- a/presentations/atls-sweden-30-years/qa-and-panel-briefing.md
+++ b/presentations/atls-sweden-30-years/qa-and-panel-briefing.md
@@ -1,0 +1,234 @@
+# Critical questions and suggested replies
+
+**Event:** ATLS Sweden — 30 years  
+**Audience:** Sweden · ATLS Region 15 · United States  
+**Your talk:** ADVANCE TRAUMA (NCT06321419) — evidence for ATLS® and a stepped-wedge cluster RCT  
+**Also:** Panel on the future of trauma care
+
+Use this as a briefing, not a script. Prefer short, calm answers. Acknowledge the question, give one clear point, then stop — or offer to continue offline.
+
+---
+
+## How to handle the room
+
+| Audience | Likely stance | Tone that lands |
+|---|---|---|
+| **Swedish faculty / instructors** | Proud of 30 years; invested in refresher, simulation, ATLS 11 rollout | Affirm local achievement; separate *programme success* from *patient-outcome evidence* |
+| **Region 15** | Protects European adaptation (“standardized flexibility”), case-based pedagogy, national guidelines | Treat Europe as a laboratory for adaptation, not a satellite of Chicago |
+| **US / ACS CoT** | Owns the brand; sensitive to “ATLS doesn’t work” headlines; proud of 11th edition | Frame the trial as *strengthening* ATLS with outcome evidence, not attacking it |
+| **Methodologists / EM sceptics** | Want RCTs, worry about secular trend, contamination, generalisability | Stay precise on design; do not oversell interim numbers |
+
+**Useful framing line (after talk or opening the panel):**  
+“ATLS has changed how we teach and talk about trauma. What we still owe patients — and funders — is clear evidence that training changes survival.”
+
+---
+
+## Part A — After the ADVANCE TRAUMA talk
+
+### A1. Evidence and the ATLS® manual
+
+**Q. Are you saying the Impact section of the ATLS manual is wrong?**  
+**Reply:** Not wrong so much as *over-interpreted*. The manual correctly summarises that ATLS improves knowledge and skills. The patient-outcome claims rest on a small set of older observational studies. Systematic reviews — including ours — still find no randomised evidence that ATLS reduces mortality. That gap is why ADVANCE TRAUMA exists.
+
+**Q. Your forest plot still shows a protective association — so isn’t the evidence already “enough”?**  
+**Reply:** Association is not causation. The pooled estimate is driven by observational studies with high heterogeneity. Confounding by trauma-system maturation, case mix, and concurrent quality programmes is plausible. Observational signals justify a trial; they do not replace one.
+
+**Q. Isn’t criticising ATLS on its anniversary ungrateful — or politically risky with ACS in the room?**  
+**Reply:** The opposite. Programmes that train more than a million physicians should welcome outcome evaluation. Sweden’s 30 years show organisational success. The scientific question is whether that organisational success translates into fewer deaths. Asking it is loyalty to patients, not disloyalty to ATLS.
+
+**Q. Why cite Ali, Rutledge, Deo, van Olden if you think they are weak?**  
+**Reply:** Because they are the studies the manual’s Impact paragraph rests on. Showing the chain from claim → citation → study design makes the evidence gap concrete rather than abstract.
+
+---
+
+### A2. Trial design and methods
+
+**Q. Why a stepped-wedge instead of a parallel cluster RCT?**  
+**Reply:** Two reasons. First, efficiency when the number of clusters is constrained by ATLS course capacity and cost. Second, equity and engagement: every participating hospital receives training. The batched design also lets us start sites as they become ready, which matters in a multi-year Indian rollout.
+
+**Q. Won’t secular trends — better equipment, blood products, triage — confound a stepped wedge?**  
+**Reply:** That is the classic threat. We address it with period effects, batch-specific secular trends, and randomisation of transition timing within batches. We also exclude the transition month from the primary analysis. Residual confounding remains a risk we will discuss transparently in the final paper.
+
+**Q. You only train 1–2 units per hospital. Isn’t contamination inevitable?**  
+**Reply:** Contamination is a real threat — and it biases toward the null, which is conservative for claiming benefit. We mitigate by collecting data on days when trained units work, and by measuring adherence in the nested staircase. If untrained colleagues adopt the same behaviours, that is clinically good and scientifically a limitation we will report.
+
+**Q. Why India, not Sweden or Europe?**  
+**Reply:** In Sweden and much of Region 15, ATLS is already standard — there is no ethical or practical control group. In our Indian partner hospitals, formal trauma life support is still uncommon, baseline mortality is high enough to detect a meaningful absolute difference, and we have a decade of collaboration and a completed pilot. That is where an outcome trial is both feasible and informative.
+
+**Q. Can results from India generalise to high-income European or US trauma systems?**  
+**Reply:** Not one-to-one. Effect sizes may differ where teams, blood banks, and imaging already exist. What *should* generalise is the principle: if a standardised course changes process adherence and survival where systems are thinner, that strengthens the case for maintaining — and refreshing — training where systems are denser. If it does not change outcomes there, we should rethink content and delivery everywhere.
+
+**Q. Isn’t a 5 percentage-point mortality reduction (20% → 15%) unrealistically large?**  
+**Reply:** It is ambitious but anchored in our updated review and pilot assumptions, and it is an *absolute* difference at a high baseline. Power curves also explore a lower-baseline scenario (10% → 7.5%), which would need denser recruitment. We would rather be powered for a clinically important effect than for a trivial one.
+
+**Q. Why 30-day in-hospital mortality as primary, not 24-hour or all-cause 90-day?**  
+**Reply:** Most preventable trauma deaths relate to early care but often declare themselves within the admission. Thirty-day in-hospital mortality balances clinical relevance with feasible ascertainment from records and transfer follow-up. We still collect 24-hour and 90-day mortality as secondaries.
+
+**Q. How do you get mortality after transfer?**  
+**Reply:** Telephonic follow-up to the patient, representative, or receiving hospital. Our pilot showed high consent for out-of-hospital follow-up and low loss to follow-up — necessary before scaling.
+
+**Q. Opt-out consent and waiver for unconscious patients — is that acceptable to a US audience?**  
+**Reply:** Patients cannot opt out of the *intervention* because training is at cluster level; consent is for *data*. Routinely recorded data and observed adherence use opt-out; non-routine outcomes use opt-in; unconscious patients without a representative are included under waiver so the sickest are not systematically excluded. Approvals are sought from Indian hospital ethics boards, TGI, and the Swedish Ethical Review Authority, with registration on CTRI and ClinicalTrials.gov.
+
+**Q. Are you testing ATLS 10 or 11? Won’t edition change invalidate the trial?**  
+**Reply:** The intervention is accredited ATLS training as delivered in India during the trial window. Edition updates are part of real-world programme life. We will document which edition each cohort received. The scientific question is whether formal ATLS training — as a living programme — improves outcomes versus no formal training, not whether one manual page beats another.
+
+**Q. Nested staircase — isn’t that just more complexity?**  
+**Reply:** Process adherence, EQ-5D-5L, and WHODAS are expensive to collect. Nesting intensive measurement around each hospital’s transition lets us test the mechanism — did behaviour change? — without observing every patient in every period.
+
+**Q. Only ~1,200 patients so far and funding is incomplete — why present this now?**  
+**Reply:** Because the anniversary is the right moment to ask Region 15 and ACS colleagues to own the evidence agenda with us. The design, rationale, and collaboration are mature; completing batches through 2028–2029 needs continued partnership and funding. Transparency about the gap is intentional.
+
+**Q. What if the trial is negative — will you say ATLS should be abandoned?**  
+**Reply:** No. A null result would mean this delivery model, in these hospitals, did not improve the primary outcome — and that trauma education must evolve (content, team training, dose, system supports). Abandoning a shared language without a better alternative would be reckless. Changing the programme based on outcome data would be responsible.
+
+**Q. What if it is positive — mandate ATLS everywhere?**  
+**Reply:** A positive result would strongly support scaling where formal training is absent, and support refresher requirements where it already exists. It would not replace trauma systems, haemorrhage control, or surgical capacity — training is one lever among many.
+
+---
+
+### A3. Sweden- and Region 15–specific pushback
+
+**Q. Sweden has used ATLS for 30 years — where is the Swedish outcome evidence?**  
+**Reply:** That is exactly the point. Penetration without outcome evaluation is common in education. Sweden’s contribution now is methodological: helping generate the RCT evidence the global programme has lacked, in a setting where equipoise still exists.
+
+**Q. Swedish courses already adapted pedagogy (case-based since 2018) and national SRB rules — isn’t your “standard ATLS” outdated?**  
+**Reply:** Local adaptation is a strength — ATLS 11’s “standardized flexibility” moves in that direction. The trial estimates the effect of accredited course delivery in India, not Swedish faculty development. European adaptations remain essential hypotheses for *how* to teach; ADVANCE TRAUMA asks *whether* teaching changes survival.
+
+**Q. With civil preparedness and mass-casualty risk rising in Sweden, shouldn’t we expand ATLS rather than study it?**  
+**Reply:** Both. Preparedness needs trained people *and* programmes that work under load. Skills fade within months; refresher and team simulation matter. Studying outcomes does not delay courses — it tells us what to double down on when every training slot competes with other readiness investments.
+
+---
+
+## Part B — Panel: the future of trauma care
+
+### B1. ATLS 11 and clinical content
+
+**Q. Is xABCDE (exsanguinating haemorrhage first) overdue, or fashion?**  
+**Reply:** Overdue formalisation of what military and many civilian systems already practise. Preventable death is still dominated by bleeding. Naming “x” changes teaching priority and skill-station design — tourniquet, packing, conversion — not just the mnemonic slide.
+
+**Q. Does ATLS still over-emphasise airway and under-emphasise blood?**  
+**Reply:** Historically yes; 11th edition narrows that gap with earlier balanced/whole-blood thinking and shock recognition (shock index, ETCO₂). The remaining challenge is implementation: course graduates need blood availability and decision support in their home hospitals, or the algorithm stays theoretical.
+
+**Q. Spinal motion restriction — evidence is weak; why is it still taught?**  
+**Reply:** Because teaching programmes lag evidence, and liability cultures are slow. Sweden already teaches to national SRB guidance rather than indiscriminate collar culture. The future is selective restriction, airway-first pragmatism, and honest admission that motion restriction is not a proven mortality intervention.
+
+**Q. Should every doctor still learn intubation in ATLS?**  
+**Reply:** No — and Swedish delivery already moves that way: recognise the need; those who intubate routinely keep the skill. ATLS’s job is priority and decision-making, not pretending every learner is an anaesthetist.
+
+**Q. Whole blood, REBOA, hybrid ORs — is ATLS still relevant?**  
+**Reply:** Yes, as the common first hour. Advanced tools fail without systematic primary survey, haemorrhage control, and transfer decisions. ATLS should stay a platform that *points to* system capabilities, not a catalogue of every device.
+
+---
+
+### B2. Education, teams, and skills fade
+
+**Q. Is a 2.5-day course obsolete in the era of simulation and CRM?**  
+**Reply:** The course is necessary but not sufficient. Future trauma education is a stack: cognitive prep → skills course → team simulation → refresher → local QI. ATLS sits in the middle of that stack. Sweden’s case-based shift and Löf team training are closer to that future than lecture-heavy models.
+
+**Q. How often should people refresh?**  
+**Reply:** Skills can fade within six months; many systems still treat a single certificate as lifetime competence. A defensible message: initial ATLS for anyone with trauma responsibility, then scheduled refresher plus regular in-situ team simulation — not badge collection.
+
+**Q. Nurses, prehospital, and students — is physician-only ATLS enough?**  
+**Reply:** No. The resuscitation is a team sport. Physician ATLS must align with ATCN/PHTLS-type training and local team roles. The “common language” only works if the whole bay speaks it.
+
+**Q. Low-volume hospitals will never see enough major trauma — what then?**  
+**Reply:** That is where standardised training and transfer decision-making matter most — Styner’s original use case. Couple ATLS with clear destination policies, tele-support, and rehearsal of rare events. Volume builds expertise; protocol plus simulation protects the rare case.
+
+---
+
+### B3. Trauma systems (Europe / Sweden / US comparison)
+
+**Q. Does Europe need US-style Level I designation?**  
+**Reply:** Europe needs *systemness* more than copied labels: destination policies, registry feedback, interfacility transfer standards, and accountable leadership. Sweden’s regional university hospitals function as de facto centres, but national destination policy and equity between regions remain unfinished business. England’s reorganisation is often cited as outcome-relevant system change — education alone does not substitute for that.
+
+**Q. Elderly falls dominate Northern European trauma — is ATLS still built for young RTC patients?**  
+**Reply:** Case mix has shifted. Future curricula must weight frailty, anticoagulation reversal, rib-fracture analgesia, and undertriage in older adults — areas ATLS 11 begins to strengthen. Triage criteria and team activation in Sweden still struggle with elderly undertriage; education and system rules must move together.
+
+**Q. Registries (SweTrau, etc.) — research toy or improvement engine?**  
+**Reply:** Only an improvement engine if feedback reaches the bay: audit filters, morbidity meetings, closed-loop QI. Training without measurement is faith; measurement without training is bureaucracy.
+
+**Q. Military / NATO preparedness vs civilian day-to-day — one curriculum or two?**  
+**Reply:** One language, different doses. Civilian ATLS/xABCDE is the shared base; military modules add prolonged field care, blast, and austere transfusion. Co-training civil–military teams on that shared base is the preparedness win.
+
+---
+
+### B4. Global equity and “standardized flexibility”
+
+**Q. Is exporting US courses to LMICs educational colonialism?**  
+**Reply:** It can be — if content ignores blood scarcity, transfer reality, and team composition. It need not be — if adaptation is explicit, local faculty lead, and we measure patient outcomes, not course counts. ADVANCE TRAUMA is an attempt to hold the export model to an outcome standard.
+
+**Q. Primary Trauma Care and other alternatives — competitors or complements?**  
+**Reply:** Complements in the ecosystem. Where ATLS is unaffordable or logistically impossible, focused alternatives may be the right tool. The field needs comparative outcome data, not brand loyalty.
+
+**Q. Prevention and trauma-informed care in ATLS 11 — mission creep?**  
+**Reply:** Understandable tension. Acute algorithms remain the core product. Prevention and trauma-informed communication are system obligations; including them in the manual signals that the first hour sits inside a longer patient and public-health story. Keep skill-station time protected for resuscitation.
+
+---
+
+### B5. Hard panel prompts (short replies)
+
+**Q. What is the single biggest threat to trauma outcomes in the next decade?**  
+**Reply:** Fragmented systems under surge — mass casualty, conflict, and everyday ED crowding — without maintained team competence. Technology will not fix an unpractised primary survey.
+
+**Q. What should ATLS stop doing?**  
+**Reply:** Treating certification as permanent competence; teaching universal hard immobilisation as dogma; and claiming patient-outcome benefit without outcome trials.
+
+**Q. What should ATLS start doing?**  
+**Reply:** Mandate refresher pathways tied to systems; measure process and outcome locally; and treat edition updates as hypotheses to evaluate, not commandments to recite.
+
+**Q. If you had one ask of ACS CoT / Region 15 today?**  
+**Reply:** Help finish rigorous outcome evaluation — including ADVANCE TRAUMA — and build a standing evidence pipeline so the 12th edition is shaped by survival data, not only by consensus.
+
+**Q. If you had one ask of Swedish regions?**  
+**Reply:** Make trauma competence maintenance a formal requirement — ATLS refresher plus team simulation — in ordinary budgets, not only in anniversary speeches.
+
+---
+
+## Part C — Bridging lines (talk → panel)
+
+Use if the moderator asks you to connect your talk to the future discussion:
+
+1. **“Education without outcomes is incomplete.”** Thirty years of Swedish ATLS prove we can organise teaching at scale. The next 30 years should prove we change survival — or change the teaching.
+
+2. **“ATLS 11 modernises content; trials modernise credibility.”** xABCDE and systems chapters are welcome. Credibility with sceptics and funders still needs randomised outcome evidence.
+
+3. **“High-income adaptation and LMIC evaluation are the same project.”** Europe adapts ATLS to local guidelines; India can still host equipoise for outcome trials. Both are needed for a honest global programme.
+
+4. **“Preparedness is rehearsal plus evidence.”** Civil defence and mass-casualty planning need ATLS literacy in depth — and the humility to fund evaluation so scarce training resources go where they save lives.
+
+---
+
+## Part D — Questions worth inviting (if the room is quiet)
+
+- “For ACS colleagues: what patient-level outcome would convince you to change a major ATLS teaching point?”
+- “For Region 15: which European adaptation (SRB, case-based teaching, airway limits) should become global default?”
+- “For Swedish regions: what would it take to fund mandatory refresher + team simulation for trauma bays?”
+- “Where should haemorrhage-control training live — ATLS, prehospital, public first aid, or all three?”
+
+---
+
+## Part E — Facts to keep at hand
+
+| Topic | Anchor |
+|---|---|
+| Trial | ADVANCE TRAUMA · NCT06321419 · batched stepped-wedge CRT · 30 hospitals · India |
+| Aim | ATLS® training vs standard care → adult trauma outcomes |
+| Primary outcome | 30-day in-hospital mortality |
+| Sample size target | >4,320 patients · 20%→15% mortality · ~90% power |
+| Status (as in deck) | ~1,200 included · batch 2 started · completion ~Dec 2028 pending funding |
+| Funders so far | Swedish Research Council · Laerdal · Region Stockholm · Swedish Society of Medicine |
+| Pilot | NCT05417243 · feasibility published / supportive unpublished metrics |
+| Evidence bottom line | Skills ↑ · randomised patient-outcome evidence still missing |
+| Sweden ATLS | Since 1996 · case-based pedagogy from 2018 · ATLS 11 from autumn 2026 |
+| Site / team | advancetrauma.info |
+
+---
+
+## Closing posture
+
+You do not need to win a debate with ACS or defend every Swedish adaptation. You need to leave three impressions:
+
+1. **Respect** for 30 years of Swedish and regional ATLS work.  
+2. **Honesty** about the patient-outcome evidence gap.  
+3. **Invitation** to make the next era of ATLS outcome-accountable — with ADVANCE TRAUMA as one concrete vehicle.

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -145,7 +145,7 @@ function renderSlide(slide: Slide): HTMLElement {
               ${(slide.stats ?? [])
                 .map(
                   (s) => `
-                <div class="stat-card" data-animate>
+                <div class="panel stat-card" data-animate>
                   <span class="stat-value">${s.value}</span>
                   <span class="stat-label">${s.label}${
                     s.source
@@ -188,18 +188,33 @@ function renderSlide(slide: Slide): HTMLElement {
       `;
       break;
 
-    case "bullets":
+    case "bullets": {
+      const items = slide.bullets ?? [];
+      const reviewRows = items.length > 0 && items.every((b) => b.includes(" — "));
       el.innerHTML = `
-        <div class="slide-inner">
+        <div class="slide-inner slide-inner--bullets">
           <h2 data-animate>${slide.title}</h2>
-          <ul class="bullet-list" data-animate-group>
-            ${(slide.bullets ?? []).map((b) => `<li data-animate>${b}</li>`).join("")}
+          <ul class="${reviewRows ? "review-list" : "bullet-list"}" data-animate-group>
+            ${items
+              .map((b, i) => {
+                if (!reviewRows) return `<li data-animate>${b}</li>`;
+                const [author, ...rest] = b.split(" — ");
+                return `<li class="review-list__item" data-animate>
+                  <span class="review-list__n" aria-hidden="true">${i + 1}</span>
+                  <div class="review-list__body">
+                    <p class="review-list__author">${author}</p>
+                    <p class="review-list__finding">${rest.join(" — ")}</p>
+                  </div>
+                </li>`;
+              })
+              .join("")}
           </ul>
           ${slide.cite ? `<p class="cite-line" data-animate>${slide.cite}</p>` : ""}
           ${slide.footer ? `<p class="slide-footer" data-animate>${slide.footer}</p>` : ""}
         </div>
       `;
       break;
+    }
 
     case "evidence":
       el.innerHTML = `
@@ -210,10 +225,10 @@ function renderSlide(slide: Slide): HTMLElement {
             ${(slide.evidence ?? [])
               .map(
                 (item) => `
-              <article class="evidence-card${evidenceCardClass(item.tag)}" data-animate>
+              <article class="panel evidence-card${evidenceCardClass(item.tag)}" data-animate>
                 <div class="evidence-card__header">
                   <span class="evidence-card__id" aria-hidden="true">${item.id}</span>
-                  ${item.tag ? `<span class="evidence-card__tag">${item.tag}</span>` : ""}
+                  ${item.tag ? `<span class="panel-tag">${item.tag}</span>` : ""}
                 </div>
                 <p class="evidence-card__claim">${item.claim}</p>
                 <p class="evidence-card__source">${item.source}</p>
@@ -249,7 +264,7 @@ function renderSlide(slide: Slide): HTMLElement {
       el.innerHTML = `
         <div class="slide-inner slide-inner--aim">
           <h2 data-animate>${slide.title}</h2>
-          <p class="aim-statement" data-animate>${slide.body}</p>
+          <p class="statement" data-animate>${slide.body}</p>
         </div>
       `;
       break;
@@ -262,15 +277,15 @@ function renderSlide(slide: Slide): HTMLElement {
           <h2 data-animate>${slide.title}</h2>
           ${
             slide.body
-              ? `<p class="outcome-hero" data-animate>${slide.body}</p>`
+              ? `<p class="statement statement--hero" data-animate>${slide.body}</p>`
               : ""
           }
           <div class="outcomes-grid outcomes-grid--${items.length}${isPrimary ? " outcomes-grid--methods" : ""}" data-animate-group>
             ${items
               .map(
                 (item) => `
-              <article class="outcome-card" data-animate>
-                ${item.tag ? `<span class="outcome-card__tag">${item.tag}</span>` : ""}
+              <article class="panel outcome-card" data-animate>
+                ${item.tag ? `<span class="panel-tag">${item.tag}</span>` : ""}
                 <p class="outcome-card__title">${item.title}</p>
                 ${item.detail ? `<p class="outcome-card__detail">${item.detail}</p>` : ""}
               </article>`
@@ -330,7 +345,7 @@ function renderSlide(slide: Slide): HTMLElement {
             ${(slide.columns ?? [])
               .map(
                 (col) => `
-              <article class="column-card" data-animate>
+              <article class="panel column-card" data-animate>
                 <h3 class="column-card__heading">${col.heading}</h3>
                 <ul class="bullet-list">
                   ${col.bullets.map((b) => `<li>${b}</li>`).join("")}
@@ -353,7 +368,7 @@ function renderSlide(slide: Slide): HTMLElement {
             ${(slide.milestones ?? [])
               .map(
                 (m) => `
-              <article class="milestone-card" data-animate>
+              <article class="panel milestone-card" data-animate>
                 ${
                   m.image
                     ? `<figure class="milestone-card__media">
@@ -517,11 +532,11 @@ function renderSlide(slide: Slide): HTMLElement {
         <div class="slide-inner">
           <h2 data-animate>${slide.title}</h2>
           <div class="implications-grid" data-animate-group>
-            <div class="implication-card implication-card--positive" data-animate>
+            <div class="panel implication-card implication-card--positive" data-animate>
               <figure><img src="./patient-review-after-illustration.png" alt="Positive outcome — ATLS improves care" /></figure>
               <p>If ATLS<sup>®</sup> <strong>improves</strong> patient outcomes, it should be further promoted.</p>
             </div>
-            <div class="implication-card implication-card--negative" data-animate>
+            <div class="panel implication-card implication-card--negative" data-animate>
               <figure><img src="./training-illustration.png" alt="Training needs to evolve" /></figure>
               <p>If ATLS<sup>®</sup> <strong>does not improve</strong> patient outcomes, trauma life support training needs to change.</p>
             </div>
@@ -558,7 +573,7 @@ function renderSlide(slide: Slide): HTMLElement {
             ${(slide.teamGroups ?? [])
               .map(
                 (group) => `
-              <article class="team-card" data-animate>
+              <article class="panel team-card" data-animate>
                 <h3 class="team-card__label">${group.label}</h3>
                 <p class="team-card__location">${group.location}</p>
                 <ul class="team-card__members">
@@ -590,7 +605,7 @@ function renderSlide(slide: Slide): HTMLElement {
             ${(slide.funders ?? [])
               .map(
                 (f) => `
-              <article class="funding-card" data-animate>
+              <article class="panel funding-card" data-animate>
                 <p class="funding-card__name">${f.name}</p>
               </article>`
               )

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -1,6 +1,13 @@
 import { animate, stagger } from "motion";
 import { slides, type Slide } from "./slides";
-import { createSteppedWedgeSvg, setRevealMonth, focusViewBox, viewBoxString, syncAxisToStage } from "./stepped-wedge";
+import {
+  createSteppedWedgeSvg,
+  createWedgeLegend,
+  setRevealMonth,
+  focusViewBox,
+  viewBoxString,
+  syncAxisToStage,
+} from "./stepped-wedge";
 import { createForestPlot, type ForestPlotController } from "./forest-plot";
 import { designRevealStageMeta, startDesignReveal, type DesignRevealControls } from "./design-reveal";
 import { createSequencesChart, createSequencesLegend } from "./sequences";
@@ -374,13 +381,47 @@ function renderSlide(slide: Slide): HTMLElement {
 
     case "design":
       el.innerHTML = `
-        <div class="slide-inner">
+        <div class="slide-inner slide-inner--design">
           <h2 data-animate>${slide.title}</h2>
           <div class="design-layout">
-            <ul class="bullet-list design-bullets" data-animate-group>
-              ${(slide.bullets ?? []).map((b) => `<li data-animate>${b}</li>`).join("")}
-            </ul>
-            <div class="wedge-container" data-animate id="wedge-mount"></div>
+            <div class="design-copy" data-animate-group>
+              ${
+                slide.body
+                  ? `<p class="design-lead" data-animate>${slide.body}</p>`
+                  : ""
+              }
+              ${
+                slide.stats?.length
+                  ? `<div class="design-metrics" data-animate>
+                      ${slide.stats
+                        .map(
+                          (s) => `
+                        <div class="design-metric">
+                          <span class="stat-value">${s.value}</span>
+                          <span class="stat-label">${s.label}</span>
+                        </div>`
+                        )
+                        .join("")}
+                    </div>`
+                  : ""
+              }
+              ${
+                slide.bullets?.length
+                  ? `<ul class="bullet-list design-bullets" data-animate-group>
+                      ${slide.bullets.map((b) => `<li data-animate>${b}</li>`).join("")}
+                    </ul>`
+                  : ""
+              }
+              ${
+                slide.footer
+                  ? `<p class="design-note" data-animate>${slide.footer}</p>`
+                  : ""
+              }
+            </div>
+            <div class="design-figure" data-animate>
+              <div class="wedge-legend-mount"></div>
+              <div class="wedge-container" id="wedge-mount"></div>
+            </div>
           </div>
         </div>
       `;
@@ -571,6 +612,8 @@ function mountSlides(): void {
         if (slide.layout === "design") {
           const data = slide.designVariant === "staircase" ? trialDesignStaircase : trialDesign;
           mount.appendChild(createSteppedWedgeSvg(data));
+          const legendMount = el.querySelector(".wedge-legend-mount");
+          if (legendMount) legendMount.appendChild(createWedgeLegend(data));
         }
         // design-animation chart is mounted by startDesignReveal.
       }

--- a/presentations/atls-sweden-30-years/src/main.ts
+++ b/presentations/atls-sweden-30-years/src/main.ts
@@ -340,10 +340,8 @@ function renderSlide(slide: Slide): HTMLElement {
     case "milestones":
       el.innerHTML = `
         <div class="slide-inner slide-inner--milestones">
-          <header class="milestones-header" data-animate>
-            <h2>${slide.title}</h2>
-            ${slide.subtitle ? `<p class="milestones-subtitle">${slide.subtitle}</p>` : ""}
-          </header>
+          <h2 data-animate>${slide.title}</h2>
+          ${slide.subtitle ? `<p class="milestones-subtitle" data-animate>${slide.subtitle}</p>` : ""}
           <div class="milestones-grid" data-animate-group>
             ${(slide.milestones ?? [])
               .map(
@@ -368,6 +366,15 @@ function renderSlide(slide: Slide): HTMLElement {
               )
               .join("")}
           </div>
+          ${
+            slide.references?.length
+              ? `<ol class="slide-references" data-animate>
+                  ${slide.references
+                    .map((ref) => `<li value="${ref.id}"><span class="ref-marker">${ref.id}.</span> ${ref.text}</li>`)
+                    .join("")}
+                </ol>`
+              : ""
+          }
         </div>
       `;
       break;

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -379,11 +379,14 @@ export const slides: Slide[] = [
     layout: "design",
     title: "Study design",
     designVariant: "main",
-    bullets: [
-      "Batched stepped-wedge cluster randomised trial",
-      "30 hospitals · 6 batches · 5 sequences · 13 months in trial",
-      "Conducted in India — ongoing collaborations >10 years; ATLS not yet standard",
+    body: "Batched stepped-wedge cluster randomised trial",
+    stats: [
+      { value: "30", label: "hospitals" },
+      { value: "6", label: "batches" },
+      { value: "5", label: "sequences" },
+      { value: "13", label: "months in trial" },
     ],
+    footer: "Conducted in India — ongoing collaborations >10 years; ATLS® not yet standard",
   },
   {
     id: "design-animation",

--- a/presentations/atls-sweden-30-years/src/slides.ts
+++ b/presentations/atls-sweden-30-years/src/slides.ts
@@ -346,31 +346,49 @@ export const slides: Slide[] = [
     milestones: [
       {
         year: "2013",
-        label: "Multicentre research",
+        label: "Multicentre research — TITCO Consortium",
         image: "./milestones/multicentre.png",
         imageAlt: "Map of India with hospital sites",
-        cite: "12",
+        cite: "1",
       },
       {
         year: "2022–2023",
-        label: "Pilot and feasibility study",
+        label: "Pilot and feasibility — Gerdin Wärnberg et al. BMJ Open 2025",
         image: "./milestones/pilot.png",
         imageAlt: "Clinicians discussing care in a hospital room",
-        cite: "14",
+        cite: "2",
       },
       {
         year: "2022–2023",
-        label: "Community consultations",
+        label: "Community consultations — David & Gerdin Wärnberg 2024",
         image: "./milestones/consultations.png",
         imageAlt: "Patient bedside discussion about ATLS",
-        cite: "13",
+        cite: "3",
       },
       {
         year: "2022–2026",
-        label: "Systematic review",
+        label: "Systematic review — Nakhid et al. 2026",
         image: "./milestones/systematic-review.png",
         imageAlt: "Nakhid et al. systematic review article in press",
-        cite: "5",
+        cite: "4",
+      },
+    ],
+    references: [
+      {
+        id: "1",
+        text: "TITCO Consortium. Towards Improved Trauma Care Outcomes in India. www.titco.org.",
+      },
+      {
+        id: "2",
+        text: "Gerdin Wärnberg M et al. Feasibility of a cluster randomised trial on the effect of trauma life support training: a pilot study in India. BMJ Open. 2025;15:e099020.",
+      },
+      {
+        id: "3",
+        text: "David S, Gerdin Wärnberg M, TERN Collaborators. Patient-reported outcomes relevant to post-discharge trauma patients in urban India. medRxiv. 2024.",
+      },
+      {
+        id: "4",
+        text: "Nakhid Z et al. Effect of trauma life support training on patient outcomes: a systematic review and meta-analysis. Scand J Trauma Resusc Emerg Med. 2026.",
       },
     ],
   },

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -316,7 +316,7 @@ body {
 
 /* ── Content slides ───────────────────────────────────────────── */
 
-.slide:not(.slide--title):not(.slide--section):not(.slide--closing):not(.slide--aim):not(.slide--outcomes):not(.slide--presenter) h2 {
+.slide:not(.slide--title):not(.slide--section):not(.slide--closing):not(.slide--presenter) h2 {
   font-family: var(--font-heading);
   font-size: clamp(1.5rem, 3.5vw, 2.2rem);
   color: var(--ink);
@@ -325,6 +325,49 @@ body {
   padding-bottom: 0.3em;
   margin-bottom: 1em;
   letter-spacing: -0.01em;
+}
+
+/* Shared statement (manual quotes, aim, primary outcome) */
+.statement {
+  margin: 0;
+  padding: 0.9rem 0 0.9rem 1.15rem;
+  border-left: 3px solid var(--accent);
+  font-family: var(--font-display);
+  font-size: clamp(1.2rem, 2.4vw, 1.65rem);
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+  max-width: 46ch;
+}
+
+.statement--hero {
+  font-size: clamp(1.55rem, 3.2vw, 2.25rem);
+  max-width: 28ch;
+  margin-bottom: 1.5rem;
+}
+
+/* Shared content panels — quiet, uniform, no hover lift */
+.panel {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--brand);
+  border-radius: var(--radius);
+}
+
+.panel-tag {
+  font-family: var(--font-body);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.2em 0.55em;
+  width: fit-content;
+  white-space: nowrap;
 }
 
 /* ── Visual abstract slide ──────────────────────────────────────── */
@@ -391,19 +434,10 @@ body {
 }
 
 .stat-card {
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   padding: 1.25rem 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
-}
-
-.stat-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 16px rgba(26, 157, 187, 0.12);
 }
 
 .stat-value {
@@ -504,35 +538,25 @@ body {
   flex-direction: column;
   gap: 0.5rem;
   padding: 1rem 1.1rem 0.9rem;
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  border-top: 4px solid var(--brand);
-  transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
-}
-
-.evidence-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(26, 157, 187, 0.1);
 }
 
 .evidence-card--manual {
-  border-top-color: var(--brand);
+  border-left-color: var(--brand);
 }
 
 .evidence-card--further {
-  border-top-color: var(--accent);
+  border-left-color: var(--accent);
 }
 
 .evidence-card--review {
-  border-top-color: var(--intervention);
+  border-left-color: var(--intervention);
 }
 
 .evidence-card--review .evidence-card__id {
   color: var(--intervention);
 }
 
-.evidence-card--review .evidence-card__tag {
+.evidence-card--review .panel-tag {
   color: var(--intervention);
   border-color: color-mix(in srgb, var(--intervention) 35%, var(--border));
   background: color-mix(in srgb, var(--intervention) 8%, var(--surface));
@@ -570,6 +594,7 @@ body {
 }
 
 .evidence-card__tag {
+  /* legacy alias — prefer .panel-tag */
   font-family: var(--font-body);
   font-size: 0.62rem;
   font-weight: 600;
@@ -578,7 +603,7 @@ body {
   color: var(--text-muted);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius);
   padding: 0.2em 0.55em;
   white-space: nowrap;
 }
@@ -622,6 +647,9 @@ body {
 .slide-inner--quote {
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  min-height: 100%;
+  max-width: 920px;
 }
 
 .slide-inner--quote h2 {
@@ -629,56 +657,42 @@ body {
 }
 
 .quote-block {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
   position: relative;
   margin: 0.5rem 0 0;
-  padding: clamp(1.75rem, 4vw, 2.75rem) clamp(1.75rem, 4vw, 2.75rem)
-    clamp(1.75rem, 4vw, 2.75rem) clamp(2.25rem, 5vw, 3.25rem);
-  background: linear-gradient(135deg, var(--surface-muted) 0%, #eef7fa 100%);
-  border: 1px solid var(--border);
-  border-left: 6px solid var(--brand);
-  border-radius: var(--radius);
-  box-shadow: 0 4px 24px rgba(8, 40, 48, 0.06);
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 .quote-block::before {
-  content: "\201C";
-  position: absolute;
-  top: 0.15em;
-  left: 0.35em;
-  font-family: var(--font-heading);
-  font-size: clamp(3.5rem, 8vw, 5.5rem);
-  line-height: 1;
-  color: color-mix(in srgb, var(--brand) 25%, transparent);
-  pointer-events: none;
+  content: none;
 }
 
 .quote-text {
-  position: relative;
-  z-index: 1;
-  font-family: var(--font-heading);
-  font-size: clamp(1.35rem, 2.8vw, 2rem);
+  margin: 0;
+  padding: 1rem 0 1rem 1.25rem;
+  border-left: 3px solid var(--accent);
+  font-family: var(--font-display);
+  font-size: clamp(1.3rem, 2.6vw, 1.8rem);
   font-weight: 600;
   color: var(--ink);
-  line-height: 1.55;
-  letter-spacing: -0.01em;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
+  max-width: 40ch;
 }
 
 .quote-block cite {
-  position: relative;
-  z-index: 1;
   display: block;
-  margin-top: 1.25em;
-  padding-top: 1em;
-  border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  margin-top: 1.25rem;
+  padding-left: 1.25rem;
   font-family: var(--font-body);
-  font-size: clamp(0.85rem, 1.6vw, 1rem);
+  font-size: clamp(0.78rem, 1.4vw, 0.9rem);
   font-style: normal;
   font-weight: 500;
   color: var(--text-muted);
+  line-height: 1.4;
+  max-width: 52ch;
 }
 
 /* ── Aim ────────────────────────────────────────────────────────── */
@@ -688,36 +702,14 @@ body {
   flex-direction: column;
   justify-content: center;
   min-height: 100%;
+  max-width: 920px;
 }
 
-.slide-inner--aim h2 {
-  flex-shrink: 0;
-  font-family: var(--font-heading);
-  font-size: clamp(1.5rem, 3.5vw, 2.2rem);
-  color: var(--ink);
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  text-align: center;
-  margin-bottom: 0;
-}
-
-.aim-statement {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-family: var(--font-body);
-  font-size: clamp(1.75rem, 3.8vw, 2.75rem);
-  font-weight: 400;
-  color: var(--ink);
-  line-height: 1.45;
-  letter-spacing: 0.01em;
-  margin: 0.75rem auto 0;
-  padding: clamp(2rem, 4vw, 2.5rem) clamp(1.5rem, 3vw, 2rem);
-  max-width: 44ch;
-  border-top: 3px solid var(--accent);
-  border-bottom: 3px solid var(--accent);
+.slide-inner--aim .statement {
+  margin-top: 0.5rem;
+  font-size: clamp(1.55rem, 3.2vw, 2.25rem);
+  max-width: 38ch;
+  padding: 1rem 0 1rem 1.25rem;
 }
 
 /* ── Outcomes ───────────────────────────────────────────────────── */
@@ -729,35 +721,8 @@ body {
   min-height: 100%;
 }
 
-.slide-inner--outcomes > h2 {
-  font-family: var(--font-heading);
-  font-size: clamp(1.5rem, 3.5vw, 2.2rem);
-  color: var(--ink);
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  border-bottom: none;
-  padding-bottom: 0;
-  margin-bottom: 0.35rem;
-  text-align: center;
-}
-
 .slide-inner--outcomes-primary > h2 {
-  margin-bottom: 0.75rem;
-}
-
-.outcome-hero {
-  text-align: center;
-  font-family: var(--font-display);
-  font-size: clamp(1.85rem, 4.2vw, 2.9rem);
-  font-weight: 600;
-  color: var(--ink);
-  line-height: 1.25;
-  letter-spacing: 0.01em;
-  margin: 0 auto 1.75rem;
-  padding: clamp(1.25rem, 3vw, 1.75rem) clamp(1rem, 2.5vw, 1.5rem);
-  max-width: 28ch;
-  border-top: 3px solid var(--accent);
-  border-bottom: 3px solid var(--accent);
+  margin-bottom: 0.85rem;
 }
 
 .outcomes-grid {
@@ -821,50 +786,26 @@ body {
   flex-direction: column;
   gap: 0.45rem;
   padding: 1.15rem 1.2rem 1.05rem;
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  border-top: 4px solid var(--brand);
-  transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
-}
-
-.outcome-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(26, 157, 187, 0.1);
 }
 
 .outcomes-grid--methods .outcome-card:nth-child(2) {
-  border-top-color: var(--accent);
+  border-left-color: var(--accent);
 }
 
 .outcomes-grid--5 .outcome-card:nth-child(2) {
-  border-top-color: var(--brand-deep);
+  border-left-color: var(--brand-deep);
 }
 
 .outcomes-grid--5 .outcome-card:nth-child(3) {
-  border-top-color: var(--accent);
+  border-left-color: var(--accent);
 }
 
 .outcomes-grid--5 .outcome-card:nth-child(4) {
-  border-top-color: var(--intervention);
+  border-left-color: var(--intervention);
 }
 
 .outcomes-grid--5 .outcome-card:nth-child(5) {
-  border-top-color: color-mix(in srgb, var(--brand) 55%, var(--accent));
-}
-
-.outcome-card__tag {
-  font-family: var(--font-body);
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 0.2em 0.55em;
-  width: fit-content;
+  border-left-color: color-mix(in srgb, var(--brand) 55%, var(--accent));
 }
 
 .outcome-card__title {
@@ -881,7 +822,15 @@ body {
   line-height: 1.4;
 }
 
-/* ── Bullets ────────────────────────────────────────────────────── */
+/* ── Bullets / review list ──────────────────────────────────────── */
+
+.slide-inner--bullets {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100%;
+  max-width: 1100px;
+}
 
 .bullet-list {
   list-style: none;
@@ -891,9 +840,10 @@ body {
 
 .bullet-list li {
   position: relative;
-  padding: 0.6em 0 0.6em 1.5em;
+  padding: 0.7em 0 0.7em 1.35em;
   border-bottom: 1px solid var(--border);
   font-size: clamp(0.95rem, 1.8vw, 1.1rem);
+  line-height: 1.45;
 }
 
 .bullet-list li:last-child {
@@ -904,11 +854,68 @@ body {
   content: "";
   position: absolute;
   left: 0;
-  top: 1.1em;
-  width: 8px;
-  height: 8px;
+  top: 1.15em;
+  width: 7px;
+  height: 7px;
   background: var(--brand);
   border-radius: 50%;
+}
+
+.review-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.15rem 0 0.15rem 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 3px solid var(--brand);
+}
+
+.review-list__item {
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  gap: 0.85rem;
+  align-items: start;
+  padding: 0.85rem 0 0.85rem 1.1rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+}
+
+.review-list__item:last-child {
+  border-bottom: none;
+}
+
+.review-list__n {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--brand-deep);
+  line-height: 1.2;
+  padding-top: 0.1rem;
+}
+
+.review-list__body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.review-list__author {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(0.95rem, 1.7vw, 1.1rem);
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.3;
+}
+
+.review-list__finding {
+  margin: 0;
+  font-size: clamp(0.88rem, 1.55vw, 1rem);
+  color: var(--text-muted);
+  line-height: 1.45;
 }
 
 .cite-line {
@@ -955,11 +962,11 @@ body {
 }
 
 .column-card {
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-top: 4px solid var(--brand);
-  border-radius: var(--radius);
   padding: clamp(1.1rem, 2.2vw, 1.5rem);
+}
+
+.column-card:nth-child(2) {
+  border-left-color: var(--accent);
 }
 
 .column-card__heading {
@@ -1031,15 +1038,6 @@ body {
   align-items: center;
   gap: 1rem;
   padding: 0.85rem 1rem;
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
-}
-
-.milestone-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 16px rgba(26, 157, 187, 0.12);
 }
 
 .milestone-card__media {
@@ -1989,24 +1987,16 @@ body {
 }
 
 .implication-card {
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   padding: 1.5rem;
   text-align: center;
-  transition: transform 0.25s var(--transition-smooth);
-}
-
-.implication-card:hover {
-  transform: translateY(-4px);
 }
 
 .implication-card--positive {
-  border-top: 4px solid var(--brand);
+  border-left-color: var(--brand);
 }
 
 .implication-card--negative {
-  border-top: 4px solid var(--intervention);
+  border-left-color: var(--intervention);
 }
 
 .implication-card figure {
@@ -2318,10 +2308,6 @@ body {
 }
 
 .team-card {
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-top: 4px solid var(--brand);
-  border-radius: var(--radius);
   padding: clamp(1rem, 2vw, 1.35rem);
 }
 
@@ -2401,12 +2387,9 @@ body {
 }
 
 .funding-card {
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
-  border-top: 4px solid var(--accent);
-  border-radius: var(--radius);
   padding: clamp(1.15rem, 2.5vw, 1.75rem);
   text-align: center;
+  border-left-color: var(--accent);
 }
 
 .funding-card__name {
@@ -2420,12 +2403,12 @@ body {
 
 .funding-note {
   margin-top: 1.75rem;
-  padding: 1rem 1.25rem;
-  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
-  border-left: 4px solid var(--accent);
-  border-radius: var(--radius);
+  padding: 0.9rem 0 0.9rem 1.15rem;
+  background: transparent;
+  border-left: 3px solid var(--accent);
+  border-radius: 0;
   font-size: clamp(0.95rem, 1.8vw, 1.1rem);
-  color: var(--text);
+  color: var(--text-muted);
   line-height: 1.45;
 }
 

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1085,17 +1085,90 @@ body {
 
 /* ── Design / stepped wedge ─────────────────────────────────────── */
 
+.slide-inner--design {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100%;
+  max-width: 1180px;
+}
+
+.slide-inner--design > h2 {
+  margin-bottom: 1.15rem;
+}
+
 .design-layout {
   display: grid;
-  grid-template-columns: 1fr 1.4fr;
-  gap: 2rem;
-  align-items: start;
+  grid-template-columns: minmax(16rem, 0.95fr) minmax(0, 1.35fr);
+  gap: clamp(1.5rem, 3.5vw, 2.75rem);
+  align-items: center;
 }
 
 @media (max-width: 900px) {
   .design-layout {
     grid-template-columns: 1fr;
+    align-items: stretch;
   }
+}
+
+.design-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+  min-width: 0;
+}
+
+.design-lead {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.25rem, 2.4vw, 1.7rem);
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+  padding: 0.85rem 0 0.85rem 1rem;
+  border-left: 3px solid var(--accent);
+}
+
+.design-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem 1.25rem;
+  padding: 0.15rem 0 0.15rem 1rem;
+}
+
+.design-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.design-metric .stat-value {
+  font-size: clamp(1.65rem, 3.4vw, 2.35rem);
+}
+
+.design-metric .stat-label {
+  font-size: clamp(0.82rem, 1.5vw, 0.95rem);
+}
+
+.design-note {
+  margin: 0;
+  padding: 0.85rem 0 0 1rem;
+  border-top: 1px solid var(--border);
+  font-size: clamp(0.9rem, 1.6vw, 1.05rem);
+  color: var(--text-muted);
+  line-height: 1.45;
+  max-width: 36ch;
+}
+
+.design-copy .design-bullets {
+  padding-left: 0;
+}
+
+.design-copy .design-bullets li {
+  font-size: clamp(0.95rem, 1.7vw, 1.1rem);
+  line-height: 1.4;
 }
 
 .design-bullets li {
@@ -1110,6 +1183,25 @@ body {
 
 .design-bullets li.is-muted {
   opacity: 0.45;
+}
+
+.design-figure {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.design-figure .wedge-legend-mount {
+  order: 1;
+}
+
+.design-figure .wedge-container {
+  order: 0;
+}
+
+.design-figure .wedge-legend {
+  justify-content: center;
 }
 
 .wedge-panel {

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -1033,7 +1033,7 @@ body {
   padding: 0.85rem 1rem;
   background: var(--surface-muted);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius);
   transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
 }
 

--- a/presentations/atls-sweden-30-years/src/style.css
+++ b/presentations/atls-sweden-30-years/src/style.css
@@ -995,36 +995,29 @@ body {
 .slide-inner--milestones {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   min-height: 100%;
 }
 
-.milestones-header {
-  text-align: center;
-  margin-bottom: 1.75rem;
-}
-
 .slide--milestones .slide-inner--milestones h2 {
-  border-bottom: none;
-  padding-bottom: 0;
-  margin-bottom: 0.25rem;
-  text-align: center;
+  margin-bottom: 0.35rem;
 }
 
 .milestones-subtitle {
+  margin: 0 0 1.5rem;
   font-family: var(--font-body);
-  font-size: clamp(0.95rem, 1.8vw, 1.15rem);
+  font-size: clamp(0.95rem, 1.8vw, 1.1rem);
   color: var(--text-muted);
   font-weight: 400;
+  line-height: 1.4;
 }
 
 .milestones-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: clamp(1.25rem, 3vw, 2.25rem) clamp(1.5rem, 4vw, 3rem);
-  max-width: 980px;
-  margin: 0 auto;
+  gap: clamp(1rem, 2.5vw, 1.75rem) clamp(1.25rem, 3.5vw, 2.5rem);
   width: 100%;
+  flex: 1;
+  align-content: center;
 }
 
 @media (max-width: 700px) {
@@ -1037,20 +1030,30 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition: transform 0.2s var(--transition-smooth), box-shadow 0.2s;
+}
+
+.milestone-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(26, 157, 187, 0.12);
 }
 
 .milestone-card__media {
   flex-shrink: 0;
-  width: clamp(5.5rem, 12vw, 7.5rem);
-  height: clamp(5.5rem, 12vw, 7.5rem);
+  width: clamp(4.75rem, 10vw, 6.5rem);
+  height: clamp(4.75rem, 10vw, 6.5rem);
   margin: 0;
   border-radius: 50%;
   overflow: hidden;
-  background: var(--surface-muted);
-  border: 3px solid var(--surface);
+  background: var(--surface);
+  border: 2px solid var(--surface);
   box-shadow:
     0 0 0 1px var(--border),
-    0 8px 24px rgba(8, 40, 48, 0.1);
+    0 6px 18px rgba(8, 40, 48, 0.08);
 }
 
 .milestone-card__media img {
@@ -1069,7 +1072,7 @@ body {
 
 .milestone-card__year {
   font-family: var(--font-display);
-  font-size: clamp(1.05rem, 2vw, 1.25rem);
+  font-size: clamp(1rem, 1.9vw, 1.2rem);
   font-weight: 600;
   color: var(--brand-deep);
   line-height: 1.2;
@@ -1077,10 +1080,15 @@ body {
 
 .milestone-card__label {
   font-family: var(--font-body);
-  font-size: clamp(0.95rem, 1.8vw, 1.15rem);
+  font-size: clamp(0.88rem, 1.6vw, 1.05rem);
   font-weight: 500;
   color: var(--ink);
   line-height: 1.35;
+}
+
+.slide-inner--milestones .slide-references {
+  margin-top: auto;
+  padding-top: 1rem;
 }
 
 /* ── Design / stepped wedge ─────────────────────────────────────── */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the ATLS Sweden 30-year deck after the trim landed on `main`. Pulls in open presentation PRs and unifies text-heavy slides with the quieter design language from the Study design polish.

### Merged into this branch
- **#57** Previous work citations + milestone styling
- **#58** Study design metrics / lead / legend layout
- **#54** Q&A and panel briefing

### Design coherence
- Shared **statement** treatment (left accent) for quotes, aim, and primary-outcome hero — no large quote cards or double horizontal rules
- Shared **panel** treatment for stats, evidence, outcomes, eligibility, team, funding, implications (left accent, muted surface, no hover lift)
- Systematic-reviews bullets become numbered **author / finding** rows with a single list accent
- Softened funding note to match statement language

### Demo
Walkthrough of redesigned text slides vs design reference:
[atls-sweden-design-coherence-walkthrough.mp4](https://cursor.com/agents/bc-10f73b6f-6935-41c4-8ff7-04b184adbdf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fatls-sweden-design-coherence-walkthrough.mp4)

[Quote slide](https://cursor.com/agents/bc-10f73b6f-6935-41c4-8ff7-04b184adbdf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslide-providers-quote.webp)
[Reviews list](https://cursor.com/agents/bc-10f73b6f-6935-41c4-8ff7-04b184adbdf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslide-reviews.webp)
[Aim statement](https://cursor.com/agents/bc-10f73b6f-6935-41c4-8ff7-04b184adbdf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslide-aim.webp)
[Design reference](https://cursor.com/agents/bc-10f73b6f-6935-41c4-8ff7-04b184adbdf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslide-design-reference.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10f73b6f-6935-41c4-8ff7-04b184adbdf2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10f73b6f-6935-41c4-8ff7-04b184adbdf2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

